### PR TITLE
Allow for SSID's containing a single quote

### DIFF
--- a/src/scripts/add-wifi-network.sh
+++ b/src/scripts/add-wifi-network.sh
@@ -3,7 +3,7 @@ if [ ! "$EUID" -eq 0 ]; then
 	echo "This script must run as root"
 	exit -1
 fi
-NETWORK=$(sh -c "wpa_passphrase '$1' '$2'")
+NETWORK=$(sh -c "wpa_passphrase \"$1\" \"$2\"")
 if [[ ! $NETWORK =~ ^network ]]; then
 	echo "Invalid wifi credentials"
 	exit -1


### PR DESCRIPTION
SSID's are allowed to contain single quotes ('). This change allows the configurator to work with SSID's (and passphrases) to contain single quotes. Previous version causes following behavior:

```
SSID: It's a great network name
Pass: RatOSIsGreat
```
`$ wpa_passphrase 'It's a great network name' 'RatOSIsGreat'`

This won't work, so it should be 

`$ wpa_passphrase "It's a great network name" "RatOSIsGreat"`

hence this change