### PR TITLE
fix: disable ratos hotspot after adding wifi since it stops it from connecting to wifi network

### DIFF
--- a/src/scripts/add-wifi-network.sh
+++ b/src/scripts/add-wifi-network.sh
@@ -106,4 +106,6 @@ WIFI_AP_PASSWD="12345678"   # wifi AP mode to create hotspot connection password
 WIFI_SSID="$1"
 WIFI_PASSWD="$2"
 __EOF
+
+systemctl disable create_ap
 fi


### PR DESCRIPTION
If we don't disable the hotspot, that takes precedence and prevents the host from connecting to the specified wifi network 