### PR TITLE
The physical Y endstop for IDEX should be at the rear of the printer by default

### DIFF
--- a/src/templates/v-core-3-idex.ts
+++ b/src/templates/v-core-3-idex.ts
@@ -139,7 +139,7 @@ ${helper.renderUserStepperSections({
 		limits: (margin) => ({
 			min: 0 - margin.min,
 			max: config.size.y + margin.max,
-			endstop: 0 - margin.min,
+			endstop: config.size.y + margin.max,
 		}),
 	},
 	y1: {


### PR DESCRIPTION
This should help with the issue VisualTech48 reported on 3/13 about homing Y in the wrong direction