### PR TITLE
use regex to remove unencrypted wifi pw

### DIFF
--- a/src/scripts/add-wifi-network.sh
+++ b/src/scripts/add-wifi-network.sh
@@ -3,7 +3,7 @@ if [ ! "$EUID" -eq 0 ]; then
 	echo "This script must run as root"
 	exit 1
 fi
-NETWORK=$(sh -c "wpa_passphrase '$1' '$2'")
+NETWORK=$(sh -c "wpa_passphrase '$1' '$2' | sed '/^\s*#psk=\".*\"$/d'")
 if [[ ! $NETWORK =~ ^network ]]; then
 	echo "Invalid wifi credentials"
 	exit 1


### PR DESCRIPTION
use regex to remove unencrypted wifi pw
test validation of encrypted psk attached

```
pi@ratos:~ $ wpa_passphrase $SSID $PASS
network={
        ssid="test"
        #psk="testdummypass"
        psk=ea20d311e6ad6a9175ef7f77d0947b85e2b30fb215274b4da15137707fe47f1e
}
pi@ratos:~ $ NETWORK=$(sh -c "wpa_passphrase '$SSID' '$PASS'|sed '/^\s*#psk=\".*\"$/d'")
pi@ratos:~ $ echo $NETWORK
network={ ssid="test" psk=ea20d311e6ad6a9175ef7f77d0947b85e2b30fb215274b4da15137707fe47f1e }
pi@ratos:~ $ NETWORK=$(sh -c "wpa_passphrase '$SSID' '$PASS'")
pi@ratos:~ $ echo $NETWORK
network={ ssid="test" #psk="testdummypass" psk=ea20d311e6ad6a9175ef7f77d0947b85e2b30fb215274b4da15137707fe47f1e }
```