### PR TITLE
MACRO: fix toolhead standby

### DIFF
--- a/configuration/macros/idex/idex.cfg
+++ b/configuration/macros/idex/idex.cfg
@@ -524,6 +524,7 @@ gcode:
 		{% else %}
 			{% set extruder_temp = extruder_other_layer_temp[new_toolhead]|float %}
 		{% endif %}
+		SET_HEATER_TEMPERATURE HEATER={'extruder' if new_toolhead == 0 else 'extruder1'} TARGET={extruder_temp}
 		TEMPERATURE_WAIT SENSOR={'extruder' if new_toolhead == 0 else 'extruder1'} MINIMUM={extruder_temp}  MAXIMUM={extruder_temp + 5}
 
 		# preextrude filament

--- a/configuration/macros/idex/idex.cfg
+++ b/configuration/macros/idex/idex.cfg
@@ -514,11 +514,15 @@ gcode:
 		# deactivate old toolhead
 		_DEACTIVATE_TOOLHEAD TOOLHEAD={old_toolhead}
 
+		# get extruder temperatures
+		{% set extruder_first_layer_temp = (printer["gcode_macro START_PRINT"].extruder_first_layer_temp|default("")).split(",") %}
+		{% set extruder_other_layer_temp = (printer["gcode_macro START_PRINT"].extruder_other_layer_temp|default("")).split(",") %}
+
 		# wait for new extruder to heat up
 		{% if printer["gcode_macro _ON_LAYER_CHANGE"].layer_number|int < 2 %}
-			{% set extruder_temp = printer["gcode_macro START_PRINT"].extruder_first_layer_temp[new_toolhead]|float %}
+			{% set extruder_temp = extruder_first_layer_temp[new_toolhead]|float %}
 		{% else %}
-			{% set extruder_temp = printer["gcode_macro START_PRINT"].extruder_other_layer_temp[new_toolhead]|float %}
+			{% set extruder_temp = extruder_other_layer_temp[new_toolhead]|float %}
 		{% endif %}
 		TEMPERATURE_WAIT SENSOR={'extruder' if new_toolhead == 0 else 'extruder1'} MINIMUM={extruder_temp}  MAXIMUM={extruder_temp + 5}
 

--- a/configuration/macros/idex/toolheads.cfg
+++ b/configuration/macros/idex/toolheads.cfg
@@ -252,12 +252,16 @@ gcode:
 	{% set square_corner_velocity = printer.toolhead.square_corner_velocity|float %}
 	SET_VELOCITY_LIMIT ACCEL={acceleration} MINIMUM_CRUISE_RATIO=0 SQUARE_CORNER_VELOCITY=20
 
+	# get extruder temperatures
+	{% set extruder_first_layer_temp = (printer["gcode_macro START_PRINT"].extruder_first_layer_temp|default("")).split(",") %}
+	{% set extruder_other_layer_temp = (printer["gcode_macro START_PRINT"].extruder_other_layer_temp|default("")).split(",") %}
+
 	# set new toolhead temperature
 	{% if needs_wakeup %}
 		{% if printer["gcode_macro _ON_LAYER_CHANGE"].layer_number|int < 2 %}
-			{% set temp = printer["gcode_macro START_PRINT"].extruder_first_layer_temp[toolhead]|float %}
+			{% set temp = extruder_first_layer_temp[toolhead]|float %}
 		{% else %}
-			{% set temp = printer["gcode_macro START_PRINT"].extruder_other_layer_temp[toolhead]|float %}
+			{% set temp = extruder_other_layer_temp[toolhead]|float %}
 		{% endif %}
 		TEMPERATURE_WAIT SENSOR={'extruder' if toolhead == 0 else 'extruder1'} MINIMUM={temp}  MAXIMUM={temp + 5}
 	{% endif %}

--- a/configuration/macros/idex/toolheads.cfg
+++ b/configuration/macros/idex/toolheads.cfg
@@ -263,6 +263,7 @@ gcode:
 		{% else %}
 			{% set temp = extruder_other_layer_temp[toolhead]|float %}
 		{% endif %}
+		SET_HEATER_TEMPERATURE HEATER={'extruder' if toolhead == 0 else 'extruder1'} TARGET={temp}
 		TEMPERATURE_WAIT SENSOR={'extruder' if toolhead == 0 else 'extruder1'} MINIMUM={temp}  MAXIMUM={temp + 5}
 	{% endif %}
 


### PR DESCRIPTION
this PR fixes the wrong usage of the extruder_first_layer_temp and extruder_other_layer_temp variable