### PR TITLE
MACRO: add basic eddy probing support

### DIFF
--- a/configuration/macros/priming.cfg
+++ b/configuration/macros/priming.cfg
@@ -21,12 +21,14 @@ variable_probe_for_priming_disable_mesh_constraints: False         # True|False 
                                                                    #              WARNING: This can result in probing outside of the bed, be careful.
 variable_adaptive_prime_offset_threshold: -1.0                     # float = threshold value used for probing sanity checks
 variable_last_z_offset: None                                       # internal use only. Do not touch!
+variable_eddy_probe_name: "probe_eddy_current my_eddy_probe"       # the config name of the eddy probe
 
 
 [gcode_macro SAVE_PROBE_RESULT]
 gcode:
 	# beacon contact config
 	{% set beacon_contact_prime_probing = true if printer["gcode_macro RatOS"].beacon_contact_prime_probing|default(false)|lower == 'true' else false %}
+	{% set eddy_probe_name = truprinter["gcode_macro RatOS"].eddy_probe_name|default('') %}
 
 	{% set last_z_offset = 9999.9 %}
 	{% if printer.configfile.settings.beacon is defined %}
@@ -42,6 +44,9 @@ gcode:
 	{% elif printer.configfile.settings.probe is defined  %}
 		{% set config_offset = printer.configfile.settings.probe.z_offset|float %}
 		{% set last_z_offset = printer.probe.last_z_result - config_offset %}
+	{% elif printer.configfile.settings["%s" % eddy_probe_name] is defined  %}
+		{% set config_offset = printer.configfile.settings["%s" % eddy_probe_name].z_offset|float %}
+		{% set last_z_offset = printer["%s" % eddy_probe_name].last_z_result - config_offset %}
 	{% endif %}
 	RATOS_ECHO PREFIX="Adaptive Mesh" MSG="Saving offset adjustment of {last_z_offset} in {params.VARIABLE|default('last_z_offset')}"
 	SET_GCODE_VARIABLE MACRO=RatOS VARIABLE={params.VARIABLE|default('last_z_offset')} VALUE={last_z_offset}
@@ -50,6 +55,7 @@ gcode:
 gcode:
 	# config
 	{% set probe_for_priming_disable_mesh_constraints = true if printer["gcode_macro RatOS"].probe_for_priming_disable_mesh_constraints|default(false)|lower == 'true' else false %}
+	{% set eddy_probe_name = truprinter["gcode_macro RatOS"].eddy_probe_name|default('') %}
 
 	{% if printer["gcode_macro RatOS"].nozzle_priming|lower != 'false' %}
 		SAVE_GCODE_STATE NAME=probe_for_priming_state
@@ -120,6 +126,10 @@ gcode:
 			{% set x_offset = printer.configfile.settings.beacon.x_offset|float %}
 			{% set y_offset = printer.configfile.settings.beacon.y_offset|float %}
 			{% set z_offset = printer.configfile.settings.beacon.trigger_distance|float %}
+		{% elif printer.configfile.settings["%s" % eddy_probe_name] is defined  %}
+			{% set x_offset = printer.configfile.settings["%s" % eddy_probe_name].x_offset|float %}
+			{% set y_offset = printer.configfile.settings["%s" % eddy_probe_name].y_offset|float %}
+			{% set z_offset = printer.configfile.settings["%s" % eddy_probe_name].z_offset|float %}
 		{% else %}
 			{ action_raise_error("No probe, beacon or bltouch section found. Adaptive priming only works with a [probe], [beacon] or [bltouch] section defined.") }
 		{% endif %}
@@ -220,6 +230,9 @@ gcode:
 description: Prints a primeblob, used internally, if configured, as part of the START_PRINT macro. 
 variable_x_offset: 5   # the prime blob x-margin 
 gcode:
+	# beacon contact config
+	{% set eddy_probe_name = truprinter["gcode_macro RatOS"].eddy_probe_name|default('') %}
+
 	# Handle toolhead settings
 	CACHE_TOOLHEAD_SETTINGS KEY="prime_blob"
 	SET_MACRO_TRAVEL_SETTINGS
@@ -351,7 +364,7 @@ gcode:
 	{% if has_start_offset_t0 %}
 		{% set start_z_probe_result_t0 = printer["gcode_macro RatOS"].probe_for_priming_result|float(9999.9) %}
 		{% set end_z_probe_result_t0 = printer["gcode_macro RatOS"].probe_for_priming_end_result|float(9999.9) %}
-		{% if printer.configfile.settings.bltouch is not defined and printer.configfile.settings.probe is not defined and printer.configfile.settings.beacon is not defined %}
+		{% if printer.configfile.settings.bltouch is not defined and printer.configfile.settings.probe is not defined and printer.configfile.settings.beacon is not defined and printer.configfile.settings["%s" % eddy_probe_name] is not defined %}
 			{ action_raise_error("No probe or bltouch section found. Adaptive priming only works with [probe], [beacon] or [bltouch].") }
 		{% endif %}
 		{% if start_z_probe_result_t0 == 9999.9 %}
@@ -376,7 +389,7 @@ gcode:
 			{% if has_start_offset_t1 %}
 				{% set start_z_probe_result_t1 = printer["gcode_macro RatOS"].probe_for_priming_result_t1|float(9999.9) %}
 				{% set end_z_probe_result_t1 = printer["gcode_macro RatOS"].probe_for_priming_end_result_t1|float(9999.9) %}
-				{% if printer.configfile.settings.bltouch is not defined and printer.configfile.settings.probe is not defined and printer.configfile.settings.beacon is not defined %}
+				{% if printer.configfile.settings.bltouch is not defined and printer.configfile.settings.probe is not defined and printer.configfile.settings.beacon is not defined and printer.configfile.settings["%s" % eddy_probe_name] is not defined %}
 					{ action_raise_error("No probe or bltouch section found. Adaptive priming only works with [probe], [beacon] or [bltouch].") }
 				{% endif %}
 				{% if start_z_probe_result_t1 == 9999.9 %}


### PR DESCRIPTION
This PR adds basic eddy probing support to ratos. It jsut makes sure that ratos uses the correct values for the prime blob probing, Its jsut a pinda alike implementation