### PR TITLE
MACRO: add beacon automatic scan option

### DIFF
--- a/configuration/macros/mesh.cfg
+++ b/configuration/macros/mesh.cfg
@@ -34,10 +34,11 @@ gcode:
 		{% set X=[0, printable_x_max] %}
 	{% endif %}
 
-	# beacon contact config
+	# beacon config
 	{% set beacon_bed_mesh_scv = printer["gcode_macro RatOS"].beacon_bed_mesh_scv|default(25)|int %}
 	{% set beacon_contact_bed_mesh_samples = printer["gcode_macro RatOS"].beacon_contact_bed_mesh_samples|default(2)|int %}
 	{% set beacon_contact_bed_mesh = true if printer["gcode_macro RatOS"].beacon_contact_bed_mesh|default(false)|lower == 'true' else false %}
+	{% set beacon_scan_method_automatic = true if printer["gcode_macro RatOS"].beacon_scan_method_automatic|default(false)|lower == 'true' else false %}
 	{% if printer.configfile.settings.beacon is defined and not beacon_contact_bed_mesh %}
 		SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY={beacon_bed_mesh_scv}
 	{% endif %}
@@ -49,13 +50,19 @@ gcode:
 		{% if printer["gcode_macro RatOS"].adaptive_mesh|lower == 'true' %}
 			CALIBRATE_ADAPTIVE_MESH PROFILE={default_profile} X0={X[0]} X1={X[1]} Y0={Y[0]} Y1={Y[1]} T={params.T|int} BOTH_TOOLHEADS={params.BOTH_TOOLHEADS} IDEX_MODE={idex_mode}
 		{% else %}
-			{% if printer.configfile.settings.beacon is defined and beacon_contact_bed_mesh %}
-				BED_MESH_CALIBRATE PROBE_METHOD=contact USE_CONTACT_AREA=1 SAMPLES={beacon_contact_bed_mesh_samples} PROFILE={default_profile} 
+			{% if printer.configfile.settings.beacon is defined %}
+				{% if beacon_contact_bed_mesh %}
+					BED_MESH_CALIBRATE PROBE_METHOD=contact USE_CONTACT_AREA=1 SAMPLES={beacon_contact_bed_mesh_samples} PROFILE={default_profile} 
+				{% else %}
+					{% if beacon_scan_method_automatic %}
+						BED_MESH_CALIBRATE METHOD=automatic PROFILE={default_profile} 
+					{% else %}
+						BED_MESH_CALIBRATE PROFILE={default_profile} 
+					{% endif %}
+				{% endif %}
+				_BEACON_APPLY_SCAN_COMPENSATION
 			{% else %}
 				BED_MESH_CALIBRATE PROFILE={default_profile} 
-				{% if printer.configfile.settings.beacon is defined %}
-					_BEACON_APPLY_SCAN_COMPENSATION
-				{% endif %}
 			{% endif %}
 		{% endif %}
 		BED_MESH_PROFILE LOAD={default_profile}
@@ -73,9 +80,10 @@ gcode:
 	{% set printable_y_max = printer["gcode_macro RatOS"].printable_y_max|float %}
 	{% set default_toolhead = printer["gcode_macro RatOS"].default_toolhead|default(0)|int %}
 
-	# beacon contact config
+	# beacon config
 	{% set beacon_contact_bed_mesh_samples = printer["gcode_macro RatOS"].beacon_contact_bed_mesh_samples|default(2)|int %}
 	{% set beacon_contact_bed_mesh = true if printer["gcode_macro RatOS"].beacon_contact_bed_mesh|default(false)|lower == 'true' else false %}
+	{% set beacon_scan_method_automatic = true if printer["gcode_macro RatOS"].beacon_scan_method_automatic|default(false)|lower == 'true' else false %}
 
 	# idex mode
 	{% set idex_mode = params.IDEX_MODE|default('')|lower %}
@@ -95,13 +103,19 @@ gcode:
 	{% if x0 >= x1 or y0 >= y1 %}
 		# coordinates are invalid, fall back to full bed mesh
 		RATOS_ECHO PREFIX="Adaptive Mesh" MSG="Invalid coordinates received. Please check your slicer settings. Falling back to full bed mesh."
-		{% if printer.configfile.settings.beacon is defined and beacon_contact_bed_mesh %}
-			BED_MESH_CALIBRATE PROBE_METHOD=contact USE_CONTACT_AREA=1 SAMPLES={beacon_contact_bed_mesh_samples} PROFILE={default_profile} 
+		{% if printer.configfile.settings.beacon is defined %}
+			{% if beacon_contact_bed_mesh %}
+				BED_MESH_CALIBRATE PROBE_METHOD=contact USE_CONTACT_AREA=1 SAMPLES={beacon_contact_bed_mesh_samples} PROFILE={default_profile} 
+			{% else %}
+				{% if beacon_scan_method_automatic %}
+					BED_MESH_CALIBRATE METHOD=automatic PROFILE={default_profile} 
+				{% else %}
+					BED_MESH_CALIBRATE PROFILE={default_profile} 
+				{% endif %}
+			{% endif %}
+			_BEACON_APPLY_SCAN_COMPENSATION
 		{% else %}
 			BED_MESH_CALIBRATE PROFILE={default_profile} 
-			{% if printer.configfile.settings.beacon is defined %}
-				_BEACON_APPLY_SCAN_COMPENSATION
-			{% endif %}
 		{% endif %}
 	{% else %}
 		# get bed mesh config object
@@ -122,13 +136,19 @@ gcode:
 		{% if mesh_x0 == min_x and mesh_y0 == min_y and mesh_x1 == max_x and mesh_y1 == max_y %}
 			# coordinates are invalid, fall back to full bed mesh
 			RATOS_ECHO PREFIX="Adaptive Mesh" MSG="Print is using the full bed, falling back to full bed mesh."
-			{% if printer.configfile.settings.beacon is defined and beacon_contact_bed_mesh %}
-				BED_MESH_CALIBRATE PROBE_METHOD=contact USE_CONTACT_AREA=1 SAMPLES={beacon_contact_bed_mesh_samples} PROFILE={default_profile} 
-			{% else %}
-				BED_MESH_CALIBRATE PROFILE={default_profile}
-				{% if printer.configfile.settings.beacon is defined %}
-					_BEACON_APPLY_SCAN_COMPENSATION
+			{% if printer.configfile.settings.beacon is defined %}
+				{% if beacon_contact_bed_mesh %}
+					BED_MESH_CALIBRATE PROBE_METHOD=contact USE_CONTACT_AREA=1 SAMPLES={beacon_contact_bed_mesh_samples} PROFILE={default_profile} 
+				{% else %}
+					{% if beacon_scan_method_automatic %}
+						BED_MESH_CALIBRATE METHOD=automatic PROFILE={default_profile} 
+					{% else %}
+						BED_MESH_CALIBRATE PROFILE={default_profile} 
+					{% endif %}
 				{% endif %}
+				_BEACON_APPLY_SCAN_COMPENSATION
+			{% else %}
+				BED_MESH_CALIBRATE PROFILE={default_profile} 
 			{% endif %}
 		{% else %}
 			{% if printer["gcode_macro RatOS"].z_probe|lower == 'stowable' %}
@@ -205,13 +225,19 @@ gcode:
 
 			# mesh
 			RATOS_ECHO PREFIX="Adaptive Mesh" MSG="mesh coordinates X0={mesh_x0} Y0={mesh_y0} X1={mesh_x1} Y1={mesh_y1}"
-			{% if printer.configfile.settings.beacon is defined and beacon_contact_bed_mesh %}
-				BED_MESH_CALIBRATE PROBE_METHOD=contact USE_CONTACT_AREA=1 SAMPLES={beacon_contact_bed_mesh_samples} PROFILE={default_profile} ALGORITHM={algorithm} MESH_MIN={mesh_x0},{mesh_y0} MESH_MAX={mesh_x1},{mesh_y1} PROBE_COUNT={mesh_count_x},{mesh_count_y} RELATIVE_REFERENCE_INDEX=-1
+			{% if printer.configfile.settings.beacon is defined %}
+				{% if beacon_contact_bed_mesh %}
+					BED_MESH_CALIBRATE PROBE_METHOD=contact USE_CONTACT_AREA=1 SAMPLES={beacon_contact_bed_mesh_samples} PROFILE={default_profile} ALGORITHM={algorithm} MESH_MIN={mesh_x0},{mesh_y0} MESH_MAX={mesh_x1},{mesh_y1} PROBE_COUNT={mesh_count_x},{mesh_count_y} RELATIVE_REFERENCE_INDEX=-1
+				{% else %}
+					{% if beacon_scan_method_automatic %}
+						BED_MESH_CALIBRATE METHOD=automatic PROFILE={default_profile} ALGORITHM={algorithm} MESH_MIN={mesh_x0},{mesh_y0} MESH_MAX={mesh_x1},{mesh_y1} PROBE_COUNT={mesh_count_x},{mesh_count_y} RELATIVE_REFERENCE_INDEX=-1
+					{% else %}
+						BED_MESH_CALIBRATE PROFILE={default_profile} ALGORITHM={algorithm} MESH_MIN={mesh_x0},{mesh_y0} MESH_MAX={mesh_x1},{mesh_y1} PROBE_COUNT={mesh_count_x},{mesh_count_y} RELATIVE_REFERENCE_INDEX=-1
+					{% endif %}
+				{% endif %}
+				_BEACON_APPLY_SCAN_COMPENSATION
 			{% else %}
 				BED_MESH_CALIBRATE PROFILE={default_profile} ALGORITHM={algorithm} MESH_MIN={mesh_x0},{mesh_y0} MESH_MAX={mesh_x1},{mesh_y1} PROBE_COUNT={mesh_count_x},{mesh_count_y} RELATIVE_REFERENCE_INDEX=-1
-				{% if printer.configfile.settings.beacon is defined %}
-					_BEACON_APPLY_SCAN_COMPENSATION
-				{% endif %}
 			{% endif %}
 			
 			# probe for priming

--- a/configuration/z-probe/beacon.cfg
+++ b/configuration/z-probe/beacon.cfg
@@ -55,6 +55,7 @@ variable_beacon_scan_compensation_profile: "Offset"     # The beacon offset prof
 variable_beacon_scan_compensation_resolution: 40        # The mesh resolution in mm for the scan compensation
 
 variable_beacon_contact_poke_bottom_limit: -1		    # The bottom limit for the contact poke test
+variable_beacon_scan_method_automatic: False            # Enables the METHOD=automatic scan option 
 
 
 #####


### PR DESCRIPTION
This PR allows a user to enable the `METHOD=automatic` feature for the beacon by setting a gcode variable