### PR TITLE
Extras: add json.schemas to vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,5 +41,11 @@
 	"shellcheck.useWorkspaceRootAsCwd": true,
 	"prettier.useTabs": true,
 	"editor.detectIndentation": false,
-	"python.REPL.enableREPLSmartSend": false
+	"python.REPL.enableREPLSmartSend": false,
+	"json.schemas":[
+		{
+			"fileMatch": ["./configuration/boards/*/board-definition.json"],
+			"url": "./configuration/boards/board-definition.schema.json"
+		}
+	]
 }


### PR DESCRIPTION
This allows vscode to lint the board schemas against the board-defintions json schema, ensuring not just valid json, but ensuring it is a valid board definition file, and will allow auto-completion of board-definition sections in vscode