### PR TITLE
Fix: Limit blob size during priming to prevent oversized blobs with large nozzles

### DIFF
--- a/configuration/macros/priming.cfg
+++ b/configuration/macros/priming.cfg
@@ -447,9 +447,9 @@ gcode:
 	G1 Z{0.5 + start_z_offset} F{z_speed}
 	# Move to final position horizontally
 	G1 Y{y_start} F{speed}
-	# Extrude a blob (split in two moves to avoid thresholds)
-	G1 F300 E{14 / ((0.4 / nozzle_diameter) ** 2)}
-	G1 F300 E{14 / ((0.4 / nozzle_diameter) ** 2)}
+	# Extrude a blob (split in two moves to avoid thresholds and limit the blob size)
+	G1 F300 E{14 / ((0.4 / [nozzle_diameter|float, 0.6]|min) ** 2)}
+	G1 F300 E{14 / ((0.4 / [nozzle_diameter|float, 0.6]|min) ** 2)}
 	# 40% fan
 	M106 S{fan_speed} 
 	# Move the extruder up by 5mm while extruding, breaks away from blob


### PR DESCRIPTION
This small fix limits the blob size during priming to prevent oversized blobs when using large nozzles (>0.6mm).

The calculation for blob size remains unchanged for nozzles up to 0.6mm, ensuring consistent behavior for smaller nozzles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the priming process for more consistent extrusion. The updated control mechanism now limits the priming blob size, ensuring a reliable and uniform start even when larger nozzles are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->