### PR TITLE
GCodeProcessor: increase lookahead line count after toolchange to accommodate long custom filament gcode.

### DIFF
--- a/src/server/gcode-processor/Actions.ts
+++ b/src/server/gcode-processor/Actions.ts
@@ -367,7 +367,7 @@ export const processToolchange: Action = (c, s) => {
 		{
 			let foundStop = false;
 			let prevZMove: ProcessLineContext | undefined;
-			for (let scan of c.scanForward(19)) {
+			for (let scan of c.scanForward(49)) {
 				const cmd = parseCommonGCodeCommandLine(scan.line);
 				if (cmd && cmd.letter === 'G' && cmd.value === '1') {
 					if (cmd.x || cmd.y) {

--- a/src/server/gcode-processor/GCodeProcessor.ts
+++ b/src/server/gcode-processor/GCodeProcessor.ts
@@ -62,7 +62,7 @@ export interface FinalizeProcessingOptions {
  **/
 export class GCodeProcessor extends SlidingWindowLineProcessor {
 	constructor(opts: GCodeProcessorOptions) {
-		super(20, 100, opts?.abortSignal);
+		super(50, 100, opts?.abortSignal);
 		this.#state = new State(
 			!!opts.printerHasIdex,
 			!!opts.quickInspectionOnly,


### PR DESCRIPTION
Suggested as a hotfix.