### PR TITLE
fix for wifi credentials using special characters

### DIFF
--- a/src/scripts/add-wifi-network.sh
+++ b/src/scripts/add-wifi-network.sh
@@ -3,7 +3,7 @@ if [ ! "$EUID" -eq 0 ]; then
 	echo "This script must run as root"
 	exit 1
 fi
-NETWORK=$(sh -c "wpa_passphrase '$1' '$2' | sed '/^\s*#psk=\".*\"$/d'")
+NETWORK=$(sh -c "wpa_passphrase \"$1\" \"$2\" | sed '/^\s*#psk=\".*\"$/d'")
 if [[ ! $NETWORK =~ ^network ]]; then
 	echo "Invalid wifi credentials"
 	exit 1


### PR DESCRIPTION
this fix correctly string escapes both wifi SSID and password being sent to wpa_passphrase
Bug found via official facebook post group post (https://www.facebook.com/share/p/15VAfvCx97/)

PR #1 can also be canceled in favor of this as that PR does not have the sed logic which removes the plain text password from the file.