### PR TITLE
get physical toolheads in case a rmmu is available

### DIFF
--- a/configuration/macros/overrides.cfg
+++ b/configuration/macros/overrides.cfg
@@ -46,6 +46,11 @@ gcode:
 	{% set t = params.T|default(-1)|int %}
 	{% set t = 0 if t == -1 else t %}
 
+	# get physical toolhead
+	{% if printer["rmmu_hub"] is defined %}
+		{% set t = printer["rmmu_hub"].logical_mapping["%s" % t]["PHYSICAL_TOOLHEAD"]|int %}
+	{% endif %}
+
 	# IDEX mode
 	{% set idex_mode = '' %}
 	{% if printer["dual_carriage"] is defined %}
@@ -105,6 +110,11 @@ gcode:
 	{% set s = params.S|default(0)|int %}
 	{% set t = params.T|default(-1)|int %}
 	{% set t = 0 if t == -1 else t %}
+
+	# get physical toolhead
+	{% if printer["rmmu_hub"] is defined %}
+		{% set t = printer["rmmu_hub"].logical_mapping["%s" % t]["PHYSICAL_TOOLHEAD"]|int %}
+	{% endif %}
 
 	DEBUG_ECHO PREFIX="M109" MSG="s: {s}, t: {t}"
 

--- a/configuration/z-probe/beacon.cfg
+++ b/configuration/z-probe/beacon.cfg
@@ -586,6 +586,11 @@ gcode:
 	# ratos variables file
 	{% set svv = printer.save_variables.variables %}
 
+	# get physical toolhead
+	{% if printer["rmmu_hub"] is defined %}
+		{% set toolhead = printer["rmmu_hub"].logical_mapping["%s" % toolhead]["PHYSICAL_TOOLHEAD"]|int %}
+	{% endif %}
+
 	{% if reset %}
 		# reset applied offset
 		SAVE_VARIABLE VARIABLE=nozzle_expansion_applied_offset VALUE=0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Temperature commands now accurately target the correct toolhead in multi-toolhead setups, ensuring precise heating adjustments.
  - Beacon calibration has been refined to improve nozzle temperature offset and scan compensation, enhancing overall system accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->