### PR TITLE
Changed filament load temperature to 240ºC

### DIFF
--- a/configuration/macros/load_filament.cfg
+++ b/configuration/macros/load_filament.cfg
@@ -12,7 +12,7 @@ gcode:
 	_LEARN_MORE_FILAMENT
 	
 	# parameter
-	{% set temp = params.TEMP|default(220)|int %}
+	{% set temp = params.TEMP|default(240)|int %}
 	{% set toolhead = params.TOOLHEAD|default(-1)|int %}
 	{% set filament_name = params._NAME|default('')|string %}
 	{% set filament_type = params._TYPE|default('')|string %}


### PR DESCRIPTION
This temperature is compatible with most common 3d priting filaments, 220º is too low to properly load ABS/ASA PC, etc....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default temperature for filament loading from 220°C to 240°C for improved process consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->