### PR TITLE
Update INITIALIZE_PA_TUNING macro

### DIFF
--- a/configuration/macros/calibration.cfg
+++ b/configuration/macros/calibration.cfg
@@ -84,6 +84,8 @@ gcode:
 		DEBUG_ECHO PREFIX="START_PA_TOWER" MSG="START: {start}, FACTOR: {factor}"
 		RATOS_ECHO MSG="Starting presssure advance tuning tower..."
 		TUNING_TOWER COMMAND=SET_PRESSURE_ADVANCE PARAMETER=ADVANCE START={start} FACTOR={factor}
+    	{% else %}
+   		RATOS_ECHO MSG="Presssure advance tuning tower requires you to be printing gcode and on layer 1 to start."
 	{% endif %}
 
 	_LEARN_MORE_CALIBRATION

--- a/configuration/macros/calibration.cfg
+++ b/configuration/macros/calibration.cfg
@@ -82,10 +82,10 @@ gcode:
 	# initialize PA tuning 
 	{% if is_printing_gcode and layer_number < 2 %}
 		DEBUG_ECHO PREFIX="START_PA_TOWER" MSG="START: {start}, FACTOR: {factor}"
-		RATOS_ECHO MSG="Starting presssure advance tuning tower..."
+		RATOS_ECHO MSG="Starting pressure advance tuning tower..."
 		TUNING_TOWER COMMAND=SET_PRESSURE_ADVANCE PARAMETER=ADVANCE START={start} FACTOR={factor}
     	{% else %}
-   		RATOS_ECHO MSG="Presssure advance tuning tower requires you to be printing gcode and on layer 1 to start."
+   		RATOS_ECHO MSG="Pressure advance tuning tower requires you to be printing gcode and on layer 1 to start."
 	{% endif %}
 
 	_LEARN_MORE_CALIBRATION


### PR DESCRIPTION
Added else statement to tell users what they did wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced feedback during the pressure advance tuning process to clearly inform users when the printer does not meet the required conditions for starting the calibration.
	- Corrected a typo in the message for starting the pressure advance tuning tower from "presssure" to "pressure."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->