### PR TITLE
add TOOLSHIFT=0 support while printing

### DIFF
--- a/configuration/macros/idex/toolheads.cfg
+++ b/configuration/macros/idex/toolheads.cfg
@@ -461,28 +461,38 @@ gcode:
 					SET_DUAL_CARRIAGE CARRIAGE=0 MODE=PRIMARY
 					G1 X{t0_act_x} F{speed}
 
-					{% if t0_distance >= t1_distance %}
-						# copy move
-						SET_DUAL_CARRIAGE CARRIAGE=1 MODE=COPY
-						G1 X{t0_act_x + (t1_new_x - t1_act_x)} Y{new_y + yoffset} F{speed}
+					{% if toolshift %}
 
-						# move T0 
-						SET_DUAL_CARRIAGE CARRIAGE=0 MODE=PRIMARY
-						G1 X{t0_new_x + xoffset} F{speed}
+						{% if t0_distance >= t1_distance %}
+							# copy move
+							SET_DUAL_CARRIAGE CARRIAGE=1 MODE=COPY
+							G1 X{t0_act_x + (t1_new_x - t1_act_x)} Y{new_y + yoffset} F{speed}
 
-					{% elif t0_distance < t1_distance %}
-						# copy move  
-						SET_DUAL_CARRIAGE CARRIAGE=1 MODE=COPY
-						G1 X{t0_new_x + xoffset} Y{new_y + yoffset} F{speed}
+							# move T0 
+							SET_DUAL_CARRIAGE CARRIAGE=0 MODE=PRIMARY
+							G1 X{t0_new_x + xoffset} F{speed}
 
+						{% elif t0_distance < t1_distance %}
+							# copy move  
+							SET_DUAL_CARRIAGE CARRIAGE=1 MODE=COPY
+							G1 X{t0_new_x + xoffset} Y{new_y + yoffset} F{speed}
+
+							# park T1
+							SET_DUAL_CARRIAGE CARRIAGE=1 MODE=PRIMARY
+							G1 X{t1_new_x} F{speed}
+
+							# move T0 
+							SET_DUAL_CARRIAGE CARRIAGE=0 MODE=PRIMARY
+							G1 X{t0_new_x + xoffset} F{speed}
+						{% endif %}
+
+					{% else %}
 						# park T1
 						SET_DUAL_CARRIAGE CARRIAGE=1 MODE=PRIMARY
 						G1 X{t1_new_x} F{speed}
 
 						# move T0 
 						SET_DUAL_CARRIAGE CARRIAGE=0 MODE=PRIMARY
-						G1 X{t0_new_x + xoffset} F{speed}
-
 					{% endif %}
 
 					# Offset move
@@ -529,27 +539,37 @@ gcode:
 					SET_DUAL_CARRIAGE CARRIAGE=1 MODE=PRIMARY
 					G1 X{t1_act_x} F{speed}
 
-					{% if t0_distance >= t1_distance %}
-						# copy move
-						SET_DUAL_CARRIAGE CARRIAGE=1 MODE=COPY
-						G1 X{t0_act_x - t1_distance + xoffset} Y{new_y + yoffset} F{speed}
+					{% if toolshift %}
 
+						{% if t0_distance >= t1_distance %}
+							# copy move
+							SET_DUAL_CARRIAGE CARRIAGE=1 MODE=COPY
+							G1 X{t0_act_x - t1_distance + xoffset} Y{new_y + yoffset} F{speed}
+
+							# park T0
+							SET_DUAL_CARRIAGE CARRIAGE=0 MODE=PRIMARY
+							G1 X{t0_new_x + xoffset} F{speed}
+
+							# move T1
+							SET_DUAL_CARRIAGE CARRIAGE=1 MODE=PRIMARY
+
+						{% elif t0_distance < t1_distance %}
+							# copy move
+							SET_DUAL_CARRIAGE CARRIAGE=1 MODE=COPY
+							G1 X{t0_new_x} Y{new_y + yoffset} F{speed}
+
+							# move T1
+							SET_DUAL_CARRIAGE CARRIAGE=1 MODE=PRIMARY
+							G1 X{t1_new_x + xoffset} F{speed}
+						{% endif %}
+
+					{% else %}
 						# park T0
 						SET_DUAL_CARRIAGE CARRIAGE=0 MODE=PRIMARY
 						G1 X{t0_new_x + xoffset} F{speed}
 
 						# move T1
 						SET_DUAL_CARRIAGE CARRIAGE=1 MODE=PRIMARY
-
-					{% elif t0_distance < t1_distance %}
-						# copy move
-						SET_DUAL_CARRIAGE CARRIAGE=1 MODE=COPY
-						G1 X{t0_new_x} Y{new_y + yoffset} F{speed}
-
-						# move T1
-						SET_DUAL_CARRIAGE CARRIAGE=1 MODE=PRIMARY
-						G1 X{t1_new_x + xoffset} F{speed}
-
 					{% endif %}
 
 					# offset correction move
@@ -839,4 +859,3 @@ gcode:
 	SET_GCODE_VARIABLE MACRO=RatOS VARIABLE=toolchange_prepurging_timer VALUE={params.AUTO_PURGE_TIME|default(0)|int}
 	SET_GCODE_VARIABLE MACRO=RatOS VARIABLE=toolchange_purge VALUE={params.PURGE|default(25)|float}
 	SET_GCODE_VARIABLE MACRO=RatOS VARIABLE=toolchange_standby_temp VALUE={params.STANDBY_TEMP|default(-1)|float}
-


### PR DESCRIPTION
While troubleshooting a problem, I noticed that _SELECT_TOOL TOOLSHIFT=0 does not work when printing.
With this small fix it now works while printing.
Toolshift can now be disabled during printing with another T0/T1 override.
[gcode_macro T0] gcode:
    {% set x = params.X|default(-1.0)|float %}
    {% set y = params.Y|default(-1.0)|float %}
    {% set z = params.Z|default(0.0)|float %}
    {% set s = params.S|default(1)|int %}
    {% if printer["gcode_macro _SELECT_TOOL"] is defined %}
        _SELECT_TOOL T=0 X={x} Y={y} Z={z} TOOLSHIFT=0
    {% endif %}

Removing XYZ to force it to disable toolshift messes up the z-hop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the toolhead management during dual carriage operations to optimize performance when tool shifting is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->