### PR TITLE
Fix CI logger issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,18 @@ jobs:
           repository: ${{ github.repository }}
           path: "ratos-configurator"
           fetch-tags: true
+
+      - name: Write environment variables to .env.local
+        run: |
+          echo "RATOS_CONFIGURATION_PATH=${{ env.RATOS_CONFIGURATION_PATH }}" > ratos-configurator/src/.env.local
+          echo "KLIPPER_CONFIG_PATH=${{ env.KLIPPER_CONFIG_PATH }}" >> ratos-configurator/src/.env.local
+          echo "RATOS_SCRIPT_DIR=${{ env.RATOS_SCRIPT_DIR }}" >> ratos-configurator/src/.env.local
+          echo "KLIPPER_DIR=${{ env.KLIPPER_DIR }}" >> ratos-configurator/src/.env.local
+          echo "KLIPPER_ENV=${{ env.KLIPPER_ENV }}" >> ratos-configurator/src/.env.local
+          echo "MOONRAKER_DIR=${{ env.MOONRAKER_DIR }}" >> ratos-configurator/src/.env.local
+          echo "LOG_FILE=${{ env.LOG_FILE }}" >> ratos-configurator/src/.env.local
+          echo "RATOS_DATA_DIR=${{ env.RATOS_DATA_DIR }}" >> ratos-configurator/src/.env.local	  
+
       - name: Extract target branch name
         shell: bash
         run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - "development"
       - "v2.1.x"
       - "monorepo"
+      - "**/devpub/**"
   pull_request:
     branches:
       - "**"
@@ -70,14 +71,6 @@ jobs:
       - name: Dependencies
         working-directory: ratos-configurator/src
         run: pnpm install --frozen-lockfile
-
-      - name: Checkout RatOS Configuration
-        uses: actions/checkout@v4
-        if: github.ref_name != 'monorepo'
-        with:
-          repository: Rat-OS/RatOS-configuration
-          path: "ratos-configuration"
-          ref: ${{ github.base_ref || github.ref_name }}
 
       - name: Checkout Klipper
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: Rat-OS/RatOS-configurator
+          repository: ${{ github.repository }}
           path: "ratos-configurator"
           fetch-tags: true
       - name: Extract target branch name

--- a/.github/workflows/publish-development.yml
+++ b/.github/workflows/publish-development.yml
@@ -3,7 +3,9 @@ name: Publish to dev-deployment
 on:
   workflow_run:
     workflows: ["CI"] # runs after CI workflow
-    branches: ["development"]
+    branches:
+      - "development"
+      - "**/devpub/**"
     types:
       - completed
 
@@ -24,8 +26,12 @@ jobs:
         id: variables
         shell: bash
         run: |
-          echo "target-branch=dev-deployment" >> "$GITHUB_OUTPUT"
-          echo "src-branch=development" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.ref_name }}" == "development" ]]; then
+            echo "target-branch=dev-deployment" >> "$GITHUB_OUTPUT"
+          else
+            echo "target-branch=${{ github.ref_name }}-deployment" >> "$GITHUB_OUTPUT"
+          fi
+          echo "src-branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v3
         with:

--- a/src/cli/logger.ts
+++ b/src/cli/logger.ts
@@ -30,7 +30,7 @@ export const getLogger = () => {
 		logger = pino({ ...globalPinoOpts }, prettyStream).child({ source: 'cli' });
 	} else {
 		// Write to file via stream instead of worker (which breaks when using `ratos development branch` to switch between deployment and development branches).
-		logger = pino({ ...globalPinoOpts }, pino.destination({ dest: environment.LOG_FILE, sync: true })).child({
+		logger = pino({ ...globalPinoOpts }, pino.destination({ dest: logFile, sync: true })).child({
 			source: 'cli',
 		});
 	}

--- a/src/server/helpers/logger.ts
+++ b/src/server/helpers/logger.ts
@@ -1,6 +1,8 @@
 import pino from 'pino';
 import { serverSchema } from '@/env/schema.mjs';
 import { globalPinoOpts } from '@/helpers/logger';
+import { existsSync } from 'fs';
+import path from 'path';
 
 let logger: pino.Logger | null = null;
 export const getLogger = () => {
@@ -8,12 +10,18 @@ export const getLogger = () => {
 		return logger;
 	}
 	const environment = serverSchema.parse(process.env);
+	const logDirExists = existsSync(path.dirname(environment.LOG_FILE));
+	const logFile = logDirExists ? environment.LOG_FILE : '/var/log/ratos-cli.log';
+	if (!logDirExists) {
+		// eslint-disable-next-line no-console
+		console.warn('cli logger logFile directory does not exist, using default', logFile);
+	}	
 	const transportOption: pino.LoggerOptions['transport'] =
 		process.env.NODE_ENV === 'development'
 			? undefined
 			: {
 					target: 'pino/file',
-					options: { destination: environment.LOG_FILE, append: true },
+					options: { destination: logFile, append: true },
 				};
 	logger = pino({ ...globalPinoOpts, transport: transportOption });
 	return logger;


### PR DESCRIPTION
This fixes an issue with the CI workflow seen eg [here](https://github.com/tg73/RatOS-configurator/actions/runs/15237568208/job/42853458960). Please review the approach taken, this is not an area of core competence for me :-) Also note that this removes the checkout of `RatOS-configuration`, so only modern monorepo-style builds are supported.

![image](https://github.com/user-attachments/assets/68e7807b-f335-47b5-a7f3-52ffbde23702)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Expanded workflow triggers to include additional branch patterns for improved automation coverage.
	- Updated workflow logic to dynamically set deployment branch names based on the current branch context.
	- Enhanced environment variable handling by writing them to a local configuration file during workflow execution.

- **Bug Fixes**
	- Improved logging system robustness by ensuring log files are written to valid directories, with fallback options if directories are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->