### PR TITLE
Support feature branch deployment builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,18 @@ jobs:
           repository: ${{ github.repository }}
           path: "ratos-configurator"
           fetch-tags: true
+
+      - name: Write environment variables to .env.local
+        run: |
+          echo "RATOS_CONFIGURATION_PATH=${{ env.RATOS_CONFIGURATION_PATH }}" > ratos-configurator/src/.env.local
+          echo "KLIPPER_CONFIG_PATH=${{ env.KLIPPER_CONFIG_PATH }}" >> ratos-configurator/src/.env.local
+          echo "RATOS_SCRIPT_DIR=${{ env.RATOS_SCRIPT_DIR }}" >> ratos-configurator/src/.env.local
+          echo "KLIPPER_DIR=${{ env.KLIPPER_DIR }}" >> ratos-configurator/src/.env.local
+          echo "KLIPPER_ENV=${{ env.KLIPPER_ENV }}" >> ratos-configurator/src/.env.local
+          echo "MOONRAKER_DIR=${{ env.MOONRAKER_DIR }}" >> ratos-configurator/src/.env.local
+          echo "LOG_FILE=${{ env.LOG_FILE }}" >> ratos-configurator/src/.env.local
+          echo "RATOS_DATA_DIR=${{ env.RATOS_DATA_DIR }}" >> ratos-configurator/src/.env.local	  
+
       - name: Extract target branch name
         shell: bash
         run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - "development"
       - "v2.1.x"
       - "monorepo"
+      - "**/devpub/**"
   pull_request:
     branches:
       - "**"
@@ -70,14 +71,6 @@ jobs:
       - name: Dependencies
         working-directory: ratos-configurator/src
         run: pnpm install --frozen-lockfile
-
-      - name: Checkout RatOS Configuration
-        uses: actions/checkout@v4
-        if: github.ref_name != 'monorepo'
-        with:
-          repository: Rat-OS/RatOS-configuration
-          path: "ratos-configuration"
-          ref: ${{ github.base_ref || github.ref_name }}
 
       - name: Checkout Klipper
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: Rat-OS/RatOS-configurator
+          repository: ${{ github.repository }}
           path: "ratos-configurator"
           fetch-tags: true
       - name: Extract target branch name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           echo "KLIPPER_ENV=${{ env.KLIPPER_ENV }}" >> ratos-configurator/src/.env.local
           echo "MOONRAKER_DIR=${{ env.MOONRAKER_DIR }}" >> ratos-configurator/src/.env.local
           echo "LOG_FILE=${{ env.LOG_FILE }}" >> ratos-configurator/src/.env.local
-          echo "RATOS_DATA_DIR=${{ env.RATOS_DATA_DIR }}" >> ratos-configurator/src/.env.local	  
+          echo "RATOS_DATA_DIR=${{ env.RATOS_DATA_DIR }}" >> ratos-configurator/src/.env.local
 
       - name: Extract target branch name
         shell: bash
@@ -71,7 +71,7 @@ jobs:
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-  
+
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
@@ -105,7 +105,7 @@ jobs:
         if: success() || failure() # run this step even if previous step failed
         with:
           project: ratos-configurator/src/tsconfig.json
-          
+
       - name: Run test suite
         working-directory: ratos-configurator/src
         if: success() || failure() # run this step even if previous step failed

--- a/.github/workflows/publish-development.yml
+++ b/.github/workflows/publish-development.yml
@@ -17,6 +17,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build and Push
+    env:
+        # Override GITHUB_REF so that workflow history is associated with the correct branch  
+        GITHUB_REF: refs/heads/${{ github.event.workflow_run.head_branch }} 
     steps:
       - if: github.event.workflow_run.conclusion != 'success'
         run: |

--- a/.github/workflows/publish-development.yml
+++ b/.github/workflows/publish-development.yml
@@ -132,6 +132,7 @@ jobs:
 
       - name: Generate Commit Message
         id: generate-commit-message
+        if: false
         shell: bash
         run: |
             # Check if the starting commit is the first commit in the repository
@@ -152,9 +153,6 @@ jobs:
           folder: .
           commit-message: |
             Deployed ${{ steps.commit-count.outputs.commit-count }} commit${{ steps.commit-count.outputs.commit-count > 1 && 's' || '' }}.
-            
-            ${{ steps.generate-commit-message.outputs.commit-message }}
-
             See the complete list of changes here:
             https://github.com/${{ github.repository }}/compare/${{ steps.last-successful-commit.outputs.commit-sha }}...${{ github.sha }}
           git-config-name: ${{ steps.git-config-for-deployment.outputs.git-config-name }}

--- a/.github/workflows/publish-development.yml
+++ b/.github/workflows/publish-development.yml
@@ -145,7 +145,10 @@ jobs:
             else
               # Get the first line of up to 50 commit messages in the range, excluding merge commits as these typically don't contain useful information
               commit_messages=$(git log -n 50 --no-merges --format="- %s" ${{ steps.last-successful-commit.outputs.commit-sha }}..${{ github.sha }})
-              echo "commit-message=$commit_messages" >> $GITHUB_OUTPUT
+              # Escape multi-line output
+              echo "commit-message<<EOF" >> $GITHUB_OUTPUT
+              echo "$commit_messages" >> $GITHUB_OUTPUT
+              echo "EOF" >> $GITHUB_OUTPUT
             fi
 
       - name: Publish to ${{ steps.variables.outputs.target-branch }}

--- a/.github/workflows/publish-development.yml
+++ b/.github/workflows/publish-development.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ steps.variables.outputs.src-branch }}
-    
+
       - name: Unshallow repository
         run: git fetch --unshallow origin ${{ steps.variables.outputs.src-branch }}
 
@@ -52,7 +52,7 @@ jobs:
         id: commit-count
         shell: bash
         run: |
-          echo "Deploying $(git rev-list --count ${{ steps.last-successful-commit.outputs.commit-sha }}..${{ github.sha }})) commits!"
+          echo "Deploying $(git rev-list --count ${{ steps.last-successful-commit.outputs.commit-sha }}..${{ github.sha }}) commits!"
           echo "commit-count=$(git rev-list --count ${{ steps.last-successful-commit.outputs.commit-sha }}..${{ github.sha }})" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v3
@@ -98,7 +98,7 @@ jobs:
       - name: Build
         working-directory: ./src
         run: pnpm build
-      
+
       - name: Build cli
         working-directory: ./src
         run: pnpm build:cli

--- a/.github/workflows/publish-development.yml
+++ b/.github/workflows/publish-development.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Show variables
         run: |
-          echo ""::notice::Source branch: ${{ steps.variables.outputs.src-branch }}"
-          echo ""::notice::Target branch: ${{ steps.variables.outputs.target-branch }}"
+          echo "Source branch: ${{ steps.variables.outputs.src-branch }}"
+          echo "Target branch: ${{ steps.variables.outputs.target-branch }}"
 
       - uses: actions/checkout@v3
         with:
@@ -47,7 +47,7 @@ jobs:
 
       - name: Get last successful commit
         id: last-successful-commit
-        uses: tylermilner/last-successful-commit-hash-action@v1
+        uses: nickderobertis/last-successful-commit-action@v1
         with:
           workflow-id: publish-development.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,8 +57,8 @@ jobs:
         id: commit-count
         shell: bash
         run: |
-          echo "Deploying $(git rev-list --count ${{ steps.last-successful-commit.outputs.commit-hash }}..${{ github.sha }})) commits!"
-          echo "commit-count=$(git rev-list --count ${{ steps.last-successful-commit.outputs.commit-hash }}..${{ github.sha }})" >> "$GITHUB_OUTPUT"
+          echo "Deploying $(git rev-list --count ${{ steps.last-successful-commit.outputs.commit-sha }}..${{ github.sha }})) commits!"
+          echo "commit-count=$(git rev-list --count ${{ steps.last-successful-commit.outputs.commit-sha }}..${{ github.sha }})" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v3
         with:
@@ -131,7 +131,7 @@ jobs:
           commit-message: |
             Deployed ${{ steps.commit-count.outputs.commit-count }} commit${{ steps.commit-count.outputs.commit-count > 1 && 's' || '' }}.
             
-            https://github.com/Rat-OS/RatOS-configurator/compare/${{ steps.last-successful-commit.outputs.commit-hash }}...${{ github.sha }}
+            https://github.com/Rat-OS/RatOS-configurator/compare/${{ steps.last-successful-commit.outputs.commit-sha }}...${{ github.sha }}
           git-config-name: Mikkel Schmidt
           git-config-email: mikkel.schmidt@gmail.com
           branch: ${{ steps.variables.outputs.target-branch }} # The branch name where you want to push the assets

--- a/.github/workflows/publish-development.yml
+++ b/.github/workflows/publish-development.yml
@@ -135,6 +135,19 @@ jobs:
             echo "git-config-email=${{ github.actor }}@users.noreply.github.com" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate Commit Message
+        id: generate-commit-message
+        shell: bash
+        run: |
+            # Check if the starting commit is the first commit in the repository
+            if [[ "$(git rev-list --max-parents=0 HEAD)" == "${{ steps.last-successful-commit.outputs.commit-sha }}" ]]; then
+              echo "commit-message=First deployment!" >> $GITHUB_OUTPUT
+            else
+              # Get the first line of up to 50 commit messages in the range, excluding merge commits as these typically don't contain useful information
+              commit_messages=$(git log -n 50 --no-merges --format="- %s" ${{ steps.last-successful-commit.outputs.commit-sha }}..${{ github.sha }})
+              echo "commit-message=$commit_messages" >> $GITHUB_OUTPUT
+            fi
+
       - name: Publish to ${{ steps.variables.outputs.target-branch }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
@@ -142,6 +155,9 @@ jobs:
           commit-message: |
             Deployed ${{ steps.commit-count.outputs.commit-count }} commit${{ steps.commit-count.outputs.commit-count > 1 && 's' || '' }}.
             
+            ${{ steps.generate-commit-message.outputs.commit-message }}
+
+            See the complete list of changes here:
             https://github.com/${{ github.repository }}/compare/${{ steps.last-successful-commit.outputs.commit-sha }}...${{ github.sha }}
           git-config-name: ${{ steps.git-config-for-deployment.outputs.git-config-name }}
           git-config-email: ${{ steps.git-config-for-deployment.outputs.git-config-email }}

--- a/.github/workflows/publish-development.yml
+++ b/.github/workflows/publish-development.yml
@@ -3,7 +3,9 @@ name: Publish to dev-deployment
 on:
   workflow_run:
     workflows: ["CI"] # runs after CI workflow
-    branches: ["development"]
+    branches:
+      - "development"
+      - "**/devpub/**"
     types:
       - completed
 
@@ -24,8 +26,12 @@ jobs:
         id: variables
         shell: bash
         run: |
-          echo "target-branch=dev-deployment" >> "$GITHUB_OUTPUT"
-          echo "src-branch=development" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.ref_name }}" == "development" ]]; then
+            echo "target-branch=dev-deployment" >> "$GITHUB_OUTPUT"
+          else
+            echo "target-branch=${{ github.ref_name }}-deployment" >> "$GITHUB_OUTPUT"
+          fi
+          echo "src-branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-development.yml
+++ b/.github/workflows/publish-development.yml
@@ -124,6 +124,17 @@ jobs:
         working-directory: ./
         run: mv src app
 
+      - name: Set Git Config for Deployment
+        id: git-config-for-deployment
+        run: |
+          if [[ "${{ github.repository_owner }}" == "Rat-OS" ]]; then
+            echo "git-config-name=Mikkel Schmidt" >> $GITHUB_OUTPUT
+            echo "git-config-email=mikkel.schmidt@gmail.com" >> $GITHUB_OUTPUT
+          else
+            echo "git-config-name=${{ github.actor }}" >> $GITHUB_OUTPUT
+            echo "git-config-email=${{ github.actor }}@users.noreply.github.com" >> $GITHUB_OUTPUT
+          fi
+
       - name: Publish to ${{ steps.variables.outputs.target-branch }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
@@ -131,7 +142,7 @@ jobs:
           commit-message: |
             Deployed ${{ steps.commit-count.outputs.commit-count }} commit${{ steps.commit-count.outputs.commit-count > 1 && 's' || '' }}.
             
-            https://github.com/Rat-OS/RatOS-configurator/compare/${{ steps.last-successful-commit.outputs.commit-sha }}...${{ github.sha }}
-          git-config-name: Mikkel Schmidt
-          git-config-email: mikkel.schmidt@gmail.com
+            https://github.com/${{ github.repository }}/compare/${{ steps.last-successful-commit.outputs.commit-sha }}...${{ github.sha }}
+          git-config-name: ${{ steps.git-config-for-deployment.outputs.git-config-name }}
+          git-config-email: ${{ steps.git-config-for-deployment.outputs.git-config-email }}
           branch: ${{ steps.variables.outputs.target-branch }} # The branch name where you want to push the assets

--- a/.github/workflows/publish-development.yml
+++ b/.github/workflows/publish-development.yml
@@ -26,12 +26,17 @@ jobs:
         id: variables
         shell: bash
         run: |
-          if [[ "${{ github.ref_name }}" == "development" ]]; then
+          if [[ "${{ github.event.workflow_run.head_branch }}" == "development" ]]; then
             echo "target-branch=dev-deployment" >> "$GITHUB_OUTPUT"
           else
-            echo "target-branch=${{ github.ref_name }}-deployment" >> "$GITHUB_OUTPUT"
+            echo "target-branch=${{ github.event.workflow_run.head_branch }}-deployment" >> "$GITHUB_OUTPUT"
           fi
-          echo "src-branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          echo "src-branch=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+
+      - name: Show variables
+        run: |
+          echo ""::notice::Source branch: ${{ steps.variables.outputs.src-branch }}"
+          echo ""::notice::Target branch: ${{ steps.variables.outputs.target-branch }}"
 
       - uses: actions/checkout@v3
         with:
@@ -46,7 +51,7 @@ jobs:
         with:
           workflow-id: publish-development.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          branch: development # This has to be the main branch of repository since all workflows are run from there
+          branch: ${{ steps.variables.outputs.src-branch }}
 
       - name: Get commit count
         id: commit-count

--- a/.github/workflows/publish-devpub.yml
+++ b/.github/workflows/publish-devpub.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ steps.variables.outputs.src-branch }}
-    
+
       - name: Unshallow repository
         run: git fetch --unshallow origin ${{ steps.variables.outputs.src-branch }}
 
@@ -46,12 +46,12 @@ jobs:
         run: |
           # Fetch the target branch
           git fetch origin ${{ steps.variables.outputs.target-branch }} || echo "Branch not found"
-          
+
           # Check if the branch exists
           if git rev-parse --verify origin/${{ steps.variables.outputs.target-branch }} >/dev/null 2>&1; then
             commit_sha=$(git show origin/${{ steps.variables.outputs.target-branch }}:.commit 2>/dev/null || echo "!NOTFOUND!")
             if [[ "$commit_sha" == "!NOTFOUND!" ]]; then
-              commit_sha="${{ github.event.workflow_run.head_sha }}"  
+              commit_sha="${{ github.event.workflow_run.head_sha }}"
               echo "Could not find .commit file, using current commit SHA: $commit_sha"
             else
               echo "Read commit SHA from .commit file: $commit_sha"
@@ -68,7 +68,7 @@ jobs:
         id: commit-count
         shell: bash
         run: |
-          echo "Deploying $(git rev-list --count ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.event.workflow_run.head_sha }})) commits!"
+          echo "Deploying $(git rev-list --count ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.event.workflow_run.head_sha }}) commits!"
           echo "commit-count=$(git rev-list --count ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.event.workflow_run.head_sha }})" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v3
@@ -114,7 +114,7 @@ jobs:
       - name: Build
         working-directory: ./src
         run: pnpm build
-      
+
       - name: Build cli
         working-directory: ./src
         run: pnpm build:cli

--- a/.github/workflows/publish-devpub.yml
+++ b/.github/workflows/publish-devpub.yml
@@ -49,10 +49,16 @@ jobs:
           
           # Check if the branch exists
           if git rev-parse --verify origin/${{ steps.variables.outputs.target-branch }} >/dev/null 2>&1; then
-            # Try to read the .commit file from the branch
-            commit_sha=$(git show origin/${{ steps.variables.outputs.target-branch }}:.commit 2>/dev/null || echo "${{ github.sha }}")
+            commit_sha=$(git show origin/${{ steps.variables.outputs.target-branch }}:.commit 2>/dev/null || echo "!NOTFOUND!")
+            if [[ "$commit_sha" == "!NOTFOUND!" ]]; then
+              commit_sha="${{ github.event.workflow_run.head_sha }}"  
+              echo "Could not find .commit file, using current commit SHA: $commit_sha"
+            else
+              echo "Read commit SHA from .commit file: $commit_sha"
+            fi
           else
-            commit_sha="${{ github.sha }}"
+            commit_sha="${{ github.event.workflow_run.head_sha }}"
+            echo "Branch ${{ steps.variables.outputs.target-branch }} does not exist, using current commit SHA: $commit_sha"
           fi
 
           # Output the result
@@ -62,8 +68,8 @@ jobs:
         id: commit-count
         shell: bash
         run: |
-          echo "Deploying $(git rev-list --count ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.sha }})) commits!"
-          echo "commit-count=$(git rev-list --count ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.sha }})" >> "$GITHUB_OUTPUT"
+          echo "Deploying $(git rev-list --count ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.event.workflow_run.head_sha }})) commits!"
+          echo "commit-count=$(git rev-list --count ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.event.workflow_run.head_sha }})" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v3
         with:
@@ -130,7 +136,7 @@ jobs:
         run: mv src app
 
       - name: Write Commit SHA to .commit
-        run: echo "${{ github.sha }}" > .commit
+        run: echo "${{ github.event.workflow_run.head_sha }}" > .commit
 
       - name: Set Git Config for Deployment
         id: git-config-for-deployment
@@ -152,7 +158,7 @@ jobs:
               echo "commit-message=First deployment!" >> $GITHUB_OUTPUT
             else
               # Get the first line of up to 50 commit messages in the range, excluding merge commits as these typically don't contain useful information
-              commit_messages=$(git log -n 50 --no-merges --format="- %s" ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.sha }})
+              commit_messages=$(git log -n 50 --no-merges --format="- %s" ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.event.workflow_run.head_sha }})
               # Escape multi-line output
               echo "commit-message<<EOF" >> $GITHUB_OUTPUT
               echo "$commit_messages" >> $GITHUB_OUTPUT
@@ -169,7 +175,7 @@ jobs:
             ${{ steps.generate-commit-message.outputs.commit-message }}
 
             See the complete list of changes here:
-            https://github.com/${{ github.repository }}/compare/${{ steps.read-commit-file.outputs.commit-sha }}...${{ github.sha }}
+            https://github.com/${{ github.repository }}/compare/${{ steps.read-commit-file.outputs.commit-sha }}...${{ github.event.workflow_run.head_sha }}
           git-config-name: ${{ steps.git-config-for-deployment.outputs.git-config-name }}
           git-config-email: ${{ steps.git-config-for-deployment.outputs.git-config-email }}
           branch: ${{ steps.variables.outputs.target-branch }} # The branch name where you want to push the assets

--- a/.github/workflows/publish-devpub.yml
+++ b/.github/workflows/publish-devpub.yml
@@ -1,10 +1,10 @@
 # .github/workflows/publish.yml
-name: Publish to dev-deployment
+name: Publish devpub branches
 on:
   workflow_run:
     workflows: ["CI"] # runs after CI workflow
     branches:
-      - "development"
+      - "**/devpub/**"
     types:
       - completed
 
@@ -25,8 +25,8 @@ jobs:
         id: variables
         shell: bash
         run: |
-          echo "target-branch=dev-deployment" >> "$GITHUB_OUTPUT"
-          echo "src-branch=development" >> "$GITHUB_OUTPUT"
+          echo "target-branch=${{ github.event.workflow_run.head_branch }}-deployment" >> "$GITHUB_OUTPUT"
+          echo "src-branch=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
 
       - name: Show variables
         run: |
@@ -40,20 +40,30 @@ jobs:
       - name: Unshallow repository
         run: git fetch --unshallow origin ${{ steps.variables.outputs.src-branch }}
 
-      - name: Get last successful commit
-        id: last-successful-commit
-        uses: nickderobertis/last-successful-commit-action@v1
-        with:
-          workflow-id: publish-development.yml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ steps.variables.outputs.src-branch }}
+      - name: Read .commit file from target branch
+        id: read-commit-file
+        shell: bash
+        run: |
+          # Fetch the target branch
+          git fetch origin ${{ steps.variables.outputs.target-branch }} || echo "Branch not found"
+          
+          # Check if the branch exists
+          if git rev-parse --verify origin/${{ steps.variables.outputs.target-branch }} >/dev/null 2>&1; then
+            # Try to read the .commit file from the branch
+            commit_sha=$(git show origin/${{ steps.variables.outputs.target-branch }}:.commit 2>/dev/null || echo "${{ github.sha }}")
+          else
+            commit_sha="${{ github.sha }}"
+          fi
+
+          # Output the result
+          echo "commit-sha=$commit_sha" >> $GITHUB_OUTPUT
 
       - name: Get commit count
         id: commit-count
         shell: bash
         run: |
-          echo "Deploying $(git rev-list --count ${{ steps.last-successful-commit.outputs.commit-sha }}..${{ github.sha }})) commits!"
-          echo "commit-count=$(git rev-list --count ${{ steps.last-successful-commit.outputs.commit-sha }}..${{ github.sha }})" >> "$GITHUB_OUTPUT"
+          echo "Deploying $(git rev-list --count ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.sha }})) commits!"
+          echo "commit-count=$(git rev-list --count ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.sha }})" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v3
         with:
@@ -119,6 +129,9 @@ jobs:
         working-directory: ./
         run: mv src app
 
+      - name: Write Commit SHA to .commit
+        run: echo "${{ github.sha }}" > .commit
+
       - name: Set Git Config for Deployment
         id: git-config-for-deployment
         run: |
@@ -135,11 +148,11 @@ jobs:
         shell: bash
         run: |
             # Check if the starting commit is the first commit in the repository
-            if [[ "$(git rev-list --max-parents=0 HEAD)" == "${{ steps.last-successful-commit.outputs.commit-sha }}" ]]; then
+            if [[ "$(git rev-list --max-parents=0 HEAD)" == "${{ steps.read-commit-file.outputs.commit-sha }}" ]]; then
               echo "commit-message=First deployment!" >> $GITHUB_OUTPUT
             else
               # Get the first line of up to 50 commit messages in the range, excluding merge commits as these typically don't contain useful information
-              commit_messages=$(git log -n 50 --no-merges --format="- %s" ${{ steps.last-successful-commit.outputs.commit-sha }}..${{ github.sha }})
+              commit_messages=$(git log -n 50 --no-merges --format="- %s" ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.sha }})
               # Escape multi-line output
               echo "commit-message<<EOF" >> $GITHUB_OUTPUT
               echo "$commit_messages" >> $GITHUB_OUTPUT
@@ -156,7 +169,7 @@ jobs:
             ${{ steps.generate-commit-message.outputs.commit-message }}
 
             See the complete list of changes here:
-            https://github.com/${{ github.repository }}/compare/${{ steps.last-successful-commit.outputs.commit-sha }}...${{ github.sha }}
+            https://github.com/${{ github.repository }}/compare/${{ steps.read-commit-file.outputs.commit-sha }}...${{ github.sha }}
           git-config-name: ${{ steps.git-config-for-deployment.outputs.git-config-name }}
           git-config-email: ${{ steps.git-config-for-deployment.outputs.git-config-email }}
           branch: ${{ steps.variables.outputs.target-branch }} # The branch name where you want to push the assets

--- a/.github/workflows/publish-devpub.yml
+++ b/.github/workflows/publish-devpub.yml
@@ -151,6 +151,7 @@ jobs:
 
       - name: Generate Commit Message
         id: generate-commit-message
+        if: false
         shell: bash
         run: |
             # Check if the starting commit is the first commit in the repository
@@ -167,7 +168,9 @@ jobs:
         with:
           folder: .
           commit-message: |
-            '"Deployed ${{ steps.commit-count.outputs.commit-count }} commit${{ steps.commit-count.outputs.commit-count > 1 && 's' || '' }}.\n\n${{ steps.generate-commit-message.outputs.commit-message }}\n\nSee the complete list of changes here:\nhttps://github.com/${{ github.repository }}/compare/${{ steps.read-commit-file.outputs.commit-sha }}...${{ github.event.workflow_run.head_sha }}"'
+            Deployed ${{ steps.commit-count.outputs.commit-count }} commit${{ steps.commit-count.outputs.commit-count > 1 && 's' || '' }}.
+            See the complete list of changes here:
+            https://github.com/${{ github.repository }}/compare/${{ steps.read-commit-file.outputs.commit-sha }}...${{ github.event.workflow_run.head_sha }}
           git-config-name: ${{ steps.git-config-for-deployment.outputs.git-config-name }}
           git-config-email: ${{ steps.git-config-for-deployment.outputs.git-config-email }}
           branch: ${{ steps.variables.outputs.target-branch }} # The branch name where you want to push the assets

--- a/.github/workflows/publish-devpub.yml
+++ b/.github/workflows/publish-devpub.yml
@@ -167,7 +167,7 @@ jobs:
         with:
           folder: .
           commit-message: |
-            "Deployed ${{ steps.commit-count.outputs.commit-count }} commit${{ steps.commit-count.outputs.commit-count > 1 && 's' || '' }}.\n\n${{ steps.generate-commit-message.outputs.commit-message }}\n\nSee the complete list of changes here:\nhttps://github.com/${{ github.repository }}/compare/${{ steps.read-commit-file.outputs.commit-sha }}...${{ github.event.workflow_run.head_sha }}"
+            '"Deployed ${{ steps.commit-count.outputs.commit-count }} commit${{ steps.commit-count.outputs.commit-count > 1 && 's' || '' }}.\n\n${{ steps.generate-commit-message.outputs.commit-message }}\n\nSee the complete list of changes here:\nhttps://github.com/${{ github.repository }}/compare/${{ steps.read-commit-file.outputs.commit-sha }}...${{ github.event.workflow_run.head_sha }}"'
           git-config-name: ${{ steps.git-config-for-deployment.outputs.git-config-name }}
           git-config-email: ${{ steps.git-config-for-deployment.outputs.git-config-email }}
           branch: ${{ steps.variables.outputs.target-branch }} # The branch name where you want to push the assets

--- a/.github/workflows/publish-devpub.yml
+++ b/.github/workflows/publish-devpub.yml
@@ -158,7 +158,7 @@ jobs:
               echo "commit-message=First deployment!" >> $GITHUB_OUTPUT
             else
               # Get the first line of up to 50 commit messages in the range, excluding merge commits as these typically don't contain useful information
-              commit_messages=$(git log -n 50 --no-merges --format="- %s" ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.event.workflow_run.head_sha }} | sed ':a;N;$!ba;s/\n/\\n/g')
+              commit_messages=$(git log -n 50 --no-merges --format="- %s" ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.event.workflow_run.head_sha }} | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/"/\\"/g')
               echo "commit-message=$commit_messages" >> $GITHUB_OUTPUT
             fi
 
@@ -167,7 +167,7 @@ jobs:
         with:
           folder: .
           commit-message: |
-            Deployed ${{ steps.commit-count.outputs.commit-count }} commit${{ steps.commit-count.outputs.commit-count > 1 && 's' || '' }}.\n\n${{ steps.generate-commit-message.outputs.commit-message }}\n\nSee the complete list of changes here:\nhttps://github.com/${{ github.repository }}/compare/${{ steps.read-commit-file.outputs.commit-sha }}...${{ github.event.workflow_run.head_sha }}
+            "Deployed ${{ steps.commit-count.outputs.commit-count }} commit${{ steps.commit-count.outputs.commit-count > 1 && 's' || '' }}.\n\n${{ steps.generate-commit-message.outputs.commit-message }}\n\nSee the complete list of changes here:\nhttps://github.com/${{ github.repository }}/compare/${{ steps.read-commit-file.outputs.commit-sha }}...${{ github.event.workflow_run.head_sha }}"
           git-config-name: ${{ steps.git-config-for-deployment.outputs.git-config-name }}
           git-config-email: ${{ steps.git-config-for-deployment.outputs.git-config-email }}
           branch: ${{ steps.variables.outputs.target-branch }} # The branch name where you want to push the assets

--- a/.github/workflows/publish-devpub.yml
+++ b/.github/workflows/publish-devpub.yml
@@ -158,11 +158,8 @@ jobs:
               echo "commit-message=First deployment!" >> $GITHUB_OUTPUT
             else
               # Get the first line of up to 50 commit messages in the range, excluding merge commits as these typically don't contain useful information
-              commit_messages=$(git log -n 50 --no-merges --format="- %s" ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.event.workflow_run.head_sha }})
-              # Escape multi-line output
-              echo "commit-message<<EOF" >> $GITHUB_OUTPUT
-              echo "$commit_messages" >> $GITHUB_OUTPUT
-              echo "EOF" >> $GITHUB_OUTPUT
+              commit_messages=$(git log -n 50 --no-merges --format="- %s" ${{ steps.read-commit-file.outputs.commit-sha }}..${{ github.event.workflow_run.head_sha }} | sed ':a;N;$!ba;s/\n/\\n/g')
+              echo "commit-message=$commit_messages" >> $GITHUB_OUTPUT
             fi
 
       - name: Publish to ${{ steps.variables.outputs.target-branch }}
@@ -170,14 +167,7 @@ jobs:
         with:
           folder: .
           commit-message: |
-            <<EOF
-            Deployed ${{ steps.commit-count.outputs.commit-count }} commit${{ steps.commit-count.outputs.commit-count > 1 && 's' || '' }}.
-            
-            ${{ steps.generate-commit-message.outputs.commit-message }}
-
-            See the complete list of changes here:
-            https://github.com/${{ github.repository }}/compare/${{ steps.read-commit-file.outputs.commit-sha }}...${{ github.event.workflow_run.head_sha }}
-            EOF
+            Deployed ${{ steps.commit-count.outputs.commit-count }} commit${{ steps.commit-count.outputs.commit-count > 1 && 's' || '' }}.\n\n${{ steps.generate-commit-message.outputs.commit-message }}\n\nSee the complete list of changes here:\nhttps://github.com/${{ github.repository }}/compare/${{ steps.read-commit-file.outputs.commit-sha }}...${{ github.event.workflow_run.head_sha }}
           git-config-name: ${{ steps.git-config-for-deployment.outputs.git-config-name }}
           git-config-email: ${{ steps.git-config-for-deployment.outputs.git-config-email }}
           branch: ${{ steps.variables.outputs.target-branch }} # The branch name where you want to push the assets

--- a/.github/workflows/publish-devpub.yml
+++ b/.github/workflows/publish-devpub.yml
@@ -170,12 +170,14 @@ jobs:
         with:
           folder: .
           commit-message: |
+            <<EOF
             Deployed ${{ steps.commit-count.outputs.commit-count }} commit${{ steps.commit-count.outputs.commit-count > 1 && 's' || '' }}.
             
             ${{ steps.generate-commit-message.outputs.commit-message }}
 
             See the complete list of changes here:
             https://github.com/${{ github.repository }}/compare/${{ steps.read-commit-file.outputs.commit-sha }}...${{ github.event.workflow_run.head_sha }}
+            EOF
           git-config-name: ${{ steps.git-config-for-deployment.outputs.git-config-name }}
           git-config-email: ${{ steps.git-config-for-deployment.outputs.git-config-email }}
           branch: ${{ steps.variables.outputs.target-branch }} # The branch name where you want to push the assets

--- a/src/cli/logger.ts
+++ b/src/cli/logger.ts
@@ -30,7 +30,7 @@ export const getLogger = () => {
 		logger = pino({ ...globalPinoOpts }, prettyStream).child({ source: 'cli' });
 	} else {
 		// Write to file via stream instead of worker (which breaks when using `ratos development branch` to switch between deployment and development branches).
-		logger = pino({ ...globalPinoOpts }, pino.destination({ dest: environment.LOG_FILE, sync: true })).child({
+		logger = pino({ ...globalPinoOpts }, pino.destination({ dest: logFile, sync: true })).child({
 			source: 'cli',
 		});
 	}

--- a/src/server/helpers/logger.ts
+++ b/src/server/helpers/logger.ts
@@ -10,12 +10,16 @@ export const getLogger = () => {
 		return logger;
 	}
 	const environment = serverSchema.parse(process.env);
-	const logDirExists = existsSync(path.dirname(environment.LOG_FILE));
-	const logFile = logDirExists ? environment.LOG_FILE : '/var/log/ratos-cli.log';
-	if (!logDirExists) {
-		// eslint-disable-next-line no-console
-		console.warn('cli logger logFile directory does not exist, using default', logFile);
-	}	
+    const logDirExists = existsSync(path.dirname(environment.LOG_FILE));
+    const fallbackPath = '/var/log/ratos-server.log';
+    const logFile = logDirExists ? environment.LOG_FILE : fallbackPath;
+    if (!logDirExists) {
+        if (!existsSync(path.dirname(fallbackPath))) {
+            console.warn('Neither configured nor fallback log directories exist. Logging may fail.');
+        }
+        // eslint-disable-next-line no-console
+        console.warn('server logger logFile directory does not exist, using default', logFile);
+    }
 	const transportOption: pino.LoggerOptions['transport'] =
 		process.env.NODE_ENV === 'development'
 			? undefined

--- a/src/server/helpers/logger.ts
+++ b/src/server/helpers/logger.ts
@@ -1,6 +1,8 @@
 import pino from 'pino';
 import { serverSchema } from '@/env/schema.mjs';
 import { globalPinoOpts } from '@/helpers/logger';
+import { existsSync } from 'fs';
+import path from 'path';
 
 let logger: pino.Logger | null = null;
 export const getLogger = () => {
@@ -8,12 +10,18 @@ export const getLogger = () => {
 		return logger;
 	}
 	const environment = serverSchema.parse(process.env);
+	const logDirExists = existsSync(path.dirname(environment.LOG_FILE));
+	const logFile = logDirExists ? environment.LOG_FILE : '/var/log/ratos-cli.log';
+	if (!logDirExists) {
+		// eslint-disable-next-line no-console
+		console.warn('cli logger logFile directory does not exist, using default', logFile);
+	}	
 	const transportOption: pino.LoggerOptions['transport'] =
 		process.env.NODE_ENV === 'development'
 			? undefined
 			: {
 					target: 'pino/file',
-					options: { destination: environment.LOG_FILE, append: true },
+					options: { destination: logFile, append: true },
 				};
 	logger = pino({ ...globalPinoOpts, transport: transportOption });
 	return logger;


### PR DESCRIPTION
... and also some improvements to `development` deployment builds on forks.

Depends on and extends PR #82 

This PR updates github workflows so that any branch matching `**/devpub/**` will be built for deployment to a branch suffixed `-deployment`.

Key points for review:

- The checkout of `RatOS-configuration` is removed. Only modern monorepo builds are supported now.
- Builds on forks (both 'development' and 'devpub') are attributed to the github actor. Builds on `Rat-OS`-owned repos are attributed to Mikkel as before.
- An attempt was made to include the commit messages of source repo commits contributing to the deployment build, but this has been mothballed for now as the `JamesIves/github-pages-deploy-action` action will fall over with arbitrary multi-line commit messages, and no workaround was found (several were tried).
- `.github/workflows/publish-devpub.yml` cannot rely on the `last-successful-commit-action`, because all `devpub` branch push-triggered runs of `publish-devpub` will run in the default branch (`development`) context, and so there is no workflow run history association with any specific `devpub` branch. Instead, a `.commit` file is written and read from the head of the deployment branch to determine the commit SHA of the last deployed source branch commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved GitHub Actions workflows for dynamic branch handling, commit referencing, Git configuration, and debugging output.
	- Added a new workflow to automate building and deploying for development publishing branches.
- **Bug Fixes**
	- Enhanced logging to ensure logs are written to a valid file path, with a fallback if the configured directory is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->