### PR TITLE
Orbitool O2s - Inverted Fan output

### DIFF
--- a/configuration/boards/ldo-orbitool-o2s/board-definition.json
+++ b/configuration/boards/ldo-orbitool-o2s/board-definition.json
@@ -13,7 +13,7 @@
 	"disableAutoFlash": false,
 	"driverVoltages": [24],
 	"hasMcuTempSensor": true,
-	"invertPinLogic": ["PB15"],
+	"invertPinLogic": ["PB0","PB15"],
 	"driverCount": 1,
 	"integratedDrivers": {
 		"extruder": "LDO-2240-UART"


### PR DESCRIPTION
Pin PB0 needs to be inverted for correct operation of the board on the RatOs default config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated board configuration to invert logic for an additional pin (PB0) on the ldo-orbitool-o2s board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->