### PR TITLE
Fix to use the v-core-pro base config files

### DIFF
--- a/src/templates/v-core-pro.ts
+++ b/src/templates/v-core-pro.ts
@@ -15,9 +15,9 @@ ${helper.renderBoards()}
 ### BASE SETUP
 #############################################################################################################
 ${helper.renderBase()}
-[include RatOS/printers/v-core-3/v-core-3.cfg]
-[include RatOS/printers/v-core-3/macros.cfg]
-[include RatOS/printers/v-core-3/${config.size.x}.cfg]
+[include RatOS/printers/v-core-pro/v-core-pro.cfg]
+[include RatOS/printers/v-core-pro/macros.cfg]
+[include RatOS/printers/v-core-pro/${config.size.x}.cfg]
 
 # Extruder
 ${helper.renderExtruder()}


### PR DESCRIPTION
Fix for issue #84 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to use "v-core-pro" files instead of "v-core-3" files for base setup, macros, and size-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->