### PR TITLE
aligning microsteps with other printers

### DIFF
--- a/configuration/printers/v-core-pro/steppers.cfg
+++ b/configuration/printers/v-core-pro/steppers.cfg
@@ -10,7 +10,7 @@ step_pin: x_step_pin
 dir_pin: x_dir_pin
 enable_pin: !x_enable_pin
 rotation_distance: 40
-microsteps: 16
+microsteps: 64
 homing_speed: 50
 homing_retract_dist: 0
 
@@ -19,7 +19,7 @@ step_pin: y_step_pin
 dir_pin: y_dir_pin
 enable_pin: !y_enable_pin
 rotation_distance: 40
-microsteps: 16
+microsteps: 64
 homing_speed: 50
 homing_retract_dist: 0
 
@@ -29,7 +29,7 @@ step_pin: z0_step_pin
 dir_pin: !z0_dir_pin
 enable_pin: !z0_enable_pin
 rotation_distance: 8
-microsteps: 16
+microsteps: 64
 position_min: -5 # Needed for z-offset calibration and tilt_adjust.
 homing_speed: 10
 
@@ -38,17 +38,17 @@ step_pin: z1_step_pin
 dir_pin: !z1_dir_pin
 enable_pin: !z1_enable_pin
 rotation_distance: 8
-microsteps: 16
+microsteps: 64
 
 [stepper_z2]
 step_pin: z2_step_pin
 dir_pin: !z2_dir_pin
 enable_pin: !z2_enable_pin
 rotation_distance: 8
-microsteps: 16
+microsteps: 64
 
 [extruder]
 step_pin: e_step_pin
 dir_pin: !e_dir_pin
 enable_pin: !e_enable_pin
-microsteps: 16
+microsteps: 64


### PR DESCRIPTION
fix for issue #88 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the microsteps setting for all stepper motors from 16 to 64 in the printer configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->