### PR TITLE
Parse RatOS dialect version when used

### DIFF
--- a/src/server/gcode-processor/Actions.ts
+++ b/src/server/gcode-processor/Actions.ts
@@ -120,9 +120,9 @@ export function validateGenerator(
 				}
 				break;
 			case GCodeFlavour.RatOS:
-				if (semver.neq('0.1', gcodeInfo.generatorVersion)) {
+				if (semver.neq('0.1', gcodeInfo.ratosDialectVersion)) {
 					throw new SlicerNotSupported(
-						`Only version 0.1 of the RatOS G-code dialect is supported. Version ${gcodeInfo.generatorVersion} is not supported.`,
+						`Only version 0.1 of the RatOS G-code dialect is supported. Version ${gcodeInfo.ratosDialectVersion} is not supported.`,
 						{ cause: gcodeInfo },
 					);
 				}


### PR DESCRIPTION
The header comment says:

https://github.com/Rat-OS/RatOS-configurator/blob/420f1a7574e79ee02aa78ee14ee80a3f8e5d63e1/src/server/gcode-processor/Actions.ts#L50-L56

However there must be an oversight since `generatorVersion` is being compared anyway. This fixes it.

---

By the way, are there any specs on what exactly qualifies as "RatOS dialect"?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected version validation for RatOS G-code flavour to ensure accurate detection and error reporting for unsupported dialect versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->