### PR TITLE
Fix Orbitool O2S fan pin definitions and add 4-pin fan support

### DIFF
--- a/configuration/boards/ldo-orbitool-o2s/board-definition.json
+++ b/configuration/boards/ldo-orbitool-o2s/board-definition.json
@@ -13,7 +13,8 @@
 	"disableAutoFlash": false,
 	"driverVoltages": [24],
 	"hasMcuTempSensor": true,
-	"invertPinLogic": ["PB0","PB15"],
+	"invertPinLogic": ["PA10","PB15"],
+	"fourPinFanConnectorCount": 2,
 	"driverCount": 1,
 	"integratedDrivers": {
 		"extruder": "LDO-2240-UART"

--- a/configuration/boards/ldo-orbitool-o2s/board-definition.json
+++ b/configuration/boards/ldo-orbitool-o2s/board-definition.json
@@ -58,10 +58,7 @@
 			"parameters": {
 				"max_power": 1,
 				"enable_pin": "PB14",
-				"shutdown_speed": 0,
-				"tachometer_pin": "PA14",
-				"tachometer_ppr": 2,
-				"tachometer_poll_interval": 0.00005
+				"shutdown_speed": 0
 			}
 		},
 		"heater_fan": {
@@ -69,10 +66,7 @@
 			"parameters": {
 				"max_power": 1,
 				"cycle_time": 0.0001,
-				"shutdown_speed": 0,
-				"tachometer_pin": "PB12",
-				"tachometer_ppr": 2,
-				"tachometer_poll_interval": 0.00005
+				"shutdown_speed": 0
 			}
 		},
 		"output_pin": {

--- a/configuration/boards/ldo-orbitool-o2s/toolboard-config.cfg
+++ b/configuration/boards/ldo-orbitool-o2s/toolboard-config.cfg
@@ -14,9 +14,10 @@ aliases:
 	bltouch_sensor_pin=PB7, bltouch_control_pin=PB9,
 	probe_pin=PA15,
 	# adxl345 cs pin
-	adxl345_cs_pin=PA4
+	adxl345_cs_pin=PA4,
 	# fans
-	fan_part_cooling_pin=PB0,
-	fan_toolhead_cooling_pin=PB15
+	fan_part_cooling_pin=PA10,
+	fan_toolhead_cooling_pin=PB15,
 	# 4 pin fans
-	4p_fan_toolhead_cooling_tach_pin=PA14,
+	4p_fan_part_cooling_pin=PB0, 4p_fan_part_cooling_tach_pin=PA14,
+	4p_toolhead_cooling_pin=PB15, 4p_toolhead_cooling_tach_pin=PB12,


### PR DESCRIPTION
This PR fixes incorrect Orbitool O2S fan pin definitions and enables the 4-pin dedicated fan option in the configurator.

Changes:
- Exposed “Digital PWM on 4-pin port” in the configurator
- Fixed fan pin aliases to match actual hardware
- Remove unnecessary 4-pin tachometer pin definitions. Previously, the configurator added tachometer fields even for 2-pin fans, which caused a 0 RPM readout on non-tacho setups.

Changes tested on dev-deployment branch and real hardware:

- 5015 24 V 2-pin fan (Input Voltage PWM) ✅
- Arctic S4028-15K 12 V 4-pin fan (Digital PWM on 4-pin port) ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for up to 2 four‑pin fan connectors.
  * Added configuration for a Sherpa Micro extruder.
* **Chores**
  * Updated fan and cooling pin mappings and board pin inversion mapping.
* **Bug Fixes**
  * Removed tachometer configuration fields (tachometer/ppr/poll) from fan and heater‑fan configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->