### PR TITLE
Update M8P 2.0 board-definition.json to fix SPI pin defines

### DIFF
--- a/configuration/boards/btt-manta-m8p-20/board-definition.json
+++ b/configuration/boards/btt-manta-m8p-20/board-definition.json
@@ -34,9 +34,9 @@
 			"cs_pin": "PC13",
 			"diag_pin": "PF4",
 			"endstop_pin": "PF4",
-			"spi_software_mosi_pin": "PC12",
-			"spi_software_miso_pin": "PC11",
-			"spi_software_sclk_pin": "PC10"
+			"spi_software_mosi_pin": "PG6",
+			"spi_software_miso_pin": "PG7",
+			"spi_software_sclk_pin": "PG8"
 		},
 		"MOTOR2": {
 			"title": "MOTOR 2",
@@ -47,9 +47,9 @@
 			"cs_pin": "PE3",
 			"diag_pin": "PF3",
 			"endstop_pin": "PF3",
-			"spi_software_mosi_pin": "PC12",
-			"spi_software_miso_pin": "PC11",
-			"spi_software_sclk_pin": "PC10"
+			"spi_software_mosi_pin": "PG6",
+			"spi_software_miso_pin": "PG7",
+			"spi_software_sclk_pin": "PG8"
 		},
 		"MOTOR3": {
 			"title": "MOTOR 3",
@@ -60,9 +60,9 @@
 			"cs_pin": "PB9",
 			"diag_pin": "PF2",
 			"endstop_pin": "PF2",
-			"spi_software_mosi_pin": "PC12",
-			"spi_software_miso_pin": "PC11",
-			"spi_software_sclk_pin": "PC10"
+			"spi_software_mosi_pin": "PG6",
+			"spi_software_miso_pin": "PG7",
+			"spi_software_sclk_pin": "PG8"
 		},
 		"MOTOR4": {
 			"title": "MOTOR 4",
@@ -73,9 +73,9 @@
 			"cs_pin": "PB5",
 			"diag_pin": "PF1",
 			"endstop_pin": "PF1",
-			"spi_software_mosi_pin": "PC12",
-			"spi_software_miso_pin": "PC11",
-			"spi_software_sclk_pin": "PC10"
+			"spi_software_mosi_pin": "PG6",
+			"spi_software_miso_pin": "PG7",
+			"spi_software_sclk_pin": "PG8"
 		},
 		"MOTOR5": {
 			"title": "MOTOR 5",
@@ -86,9 +86,9 @@
 			"cs_pin": "PG14",
 			"diag_pin": "PF0",
 			"endstop_pin": "PF0",
-			"spi_software_mosi_pin": "PC12",
-			"spi_software_miso_pin": "PC11",
-			"spi_software_sclk_pin": "PC10"
+			"spi_software_mosi_pin": "PG6",
+			"spi_software_miso_pin": "PG7",
+			"spi_software_sclk_pin": "PG8"
 		},
 		"MOTOR6": {
 			"title": "MOTOR 6",
@@ -99,9 +99,9 @@
 			"cs_pin": "PG10",
 			"diag_pin": "PC15",
 			"endstop_pin": "PC15",
-			"spi_software_mosi_pin": "PC12",
-			"spi_software_miso_pin": "PC11",
-			"spi_software_sclk_pin": "PC10"
+			"spi_software_mosi_pin": "PG6",
+			"spi_software_miso_pin": "PG7",
+			"spi_software_sclk_pin": "PG8"
 		},
 		"MOTOR7": {
 			"title": "MOTOR 7",
@@ -110,9 +110,9 @@
 			"dir_pin": "PD3",
 			"uart_pin": "PD5",
 			"cs_pin": "PD5",
-			"spi_software_mosi_pin": "PC12",
-			"spi_software_miso_pin": "PC11",
-			"spi_software_sclk_pin": "PC10"
+			"spi_software_mosi_pin": "PG6",
+			"spi_software_miso_pin": "PG7",
+			"spi_software_sclk_pin": "PG8"
 		},
 		"MOTOR8": {
 			"title": "MOTOR 8",
@@ -121,9 +121,9 @@
 			"dir_pin": "PC8",
 			"uart_pin": "PC6",
 			"cs_pin": "PC6",
-			"spi_software_mosi_pin": "PC12",
-			"spi_software_miso_pin": "PC11",
-			"spi_software_sclk_pin": "PC10"
+			"spi_software_mosi_pin": "PG6",
+			"spi_software_miso_pin": "PG7",
+			"spi_software_sclk_pin": "PG8"
 		}
 	},
 	"ADXL345SPI": {
@@ -136,9 +136,9 @@
 	},
 	"stepperSPI": {
 		"software": {
-			"sclk": "PC10",
-			"mosi": "PC12",
-			"miso": "PC11"
+			"sclk": "PG8",
+			"mosi": "PG6",
+			"miso": "PG7"
 		}
 	}
 }


### PR DESCRIPTION
Fixed M8P 2.0 SPI defines

With the previous defaults SPI TMC5160 motor drivers would not work