### PR TITLE
fix(cli): ensure `ratos development` correctly identifies deployment branch names

### DIFF
--- a/src/cli/commands/development.tsx
+++ b/src/cli/commands/development.tsx
@@ -37,6 +37,8 @@ const replaceInTempEnvFile = async (
 	await replaceInFileByLine(tempEnvFile, searchOrReplacer, replace);
 };
 
+// Conventionally, deployment branches have a "-deployment" suffix. The test here is a bit more permissive,
+// and allows for example "-deployment-2" suffixes, to allow for multiple deployment branches if needed.
 const isDeploymentBranch = (branch: string) => branch.indexOf('-deployment') > -1;
 
 const renderBranchInfo = async ($: Shell) => {
@@ -185,8 +187,7 @@ const development = (program: Command) => {
 							await $`git checkout ${currentBranch}`;
 							return { newName: 'Aborted', stepStatus: 'error' };
 						}
-						// Conventionally, deployment branches have a "-deployment" suffix
-						if (newBranch.endsWith('-deployment')) {
+						if (isDeploymentBranch(newBranch)) {
 							getLogger().info(`Switched to deployment branch "${newBranch}"`);
 							helpers.insertStep({
 								name: `Adjusting environment for deployment branch ${newBranch}`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment branch detection to be more flexible—now recognizes branches containing "-deployment" anywhere in the name, rather than only those strictly ending with the suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->