### PR TITLE
fix(boards): fix incorrect PA0 and PA2 pin assignments on Octopus Pro H723 V1.1 that were swapped between y1_enable_pin and e_heater_pin

### DIFF
--- a/configuration/boards/btt-octopus-pro-h723-11/config.cfg
+++ b/configuration/boards/btt-octopus-pro-h723-11/config.cfg
@@ -16,7 +16,7 @@ aliases:
   z3_step_pin=PF9,	z3_dir_pin=PF10, z3_enable_pin=PG2,	z3_uart_pin=PF2, z3_diag_pin=null, # Driver 4 for Voron 2.4 support
   e_step_pin=PF11,  e_dir_pin=PG3,   e_enable_pin=PG5,  e_uart_pin=PC6,  e_diag_pin=null, # Driver 2
   # Hybrid CoreXY Single Toolhead
-  y1_step_pin=PG4,  y1_dir_pin=PC1,  y1_enable_pin=PA0,   y1_uart_pin=PC7,   y1_diag_pin=PG11, # Driver 3
+  y1_step_pin=PG4,  y1_dir_pin=PC1,  y1_enable_pin=PA2,   y1_uart_pin=PC7,   y1_diag_pin=PG11, # Driver 3
   x1_step_pin=PF9,  x1_dir_pin=PF10, x1_enable_pin=PG2,   x1_uart_pin=PF2,   x1_diag_pin=PG12, # Driver 4
   # Hybrid CoreXY IDEX
   dual_carriage_step_pin=PF9,   dual_carriage_dir_pin=PF10,   dual_carriage_enable_pin=PG2,   dual_carriage_uart_pin=PF2,   dual_carriage_diag_pin=PG12, # Driver 4
@@ -24,7 +24,7 @@ aliases:
   # SPI Drivers
   stepper_spi_mosi_pin=PA7,  stepper_spi_miso_pin=PA6,  stepper_spi_sclk_pin=PA5,
   # extrusion
-  e_heater_pin=PA2,  e_sensor_pin=PF4,
+  e_heater_pin=PA0,  e_sensor_pin=PF4,
   # accel
   adxl345_cs_pin=PA15,
   # auto leveling


### PR DESCRIPTION
Updated to use the correct pin for the btt octopus pro h723 v1.1

<img width="854" height="467" alt="image" src="https://github.com/user-attachments/assets/abaddbab-d379-4195-8c1b-add757484fc3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted pin assignments for the BTT Octopus Pro H723 board: secondary Y-enable and extruder heater pins swapped. Extruder sensor and status LED mappings remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rat-OS/RatOS-configurator/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->