### PR TITLE
fix(boards): corrections for VAOC led pin on Octopus Pro H723 V1.1 and filament sensor runout pin on EBB42 Gen 2

### DIFF
--- a/configuration/boards/btt-ebb42-gen2-10/toolboard-config.cfg
+++ b/configuration/boards/btt-ebb42-gen2-10/toolboard-config.cfg
@@ -38,7 +38,7 @@ aliases:
 	fan_toolhead_cooling_pin=PB4
 
 	# filament sensors
-	filament_sensor_runout_pin=PA3,
+	filament_sensor_runout_pin=PA10,
 	filament_sensor_motion_pin=PA9,
 
 [mcu toolboard]

--- a/configuration/boards/btt-octopus-pro-h723-11/config.cfg
+++ b/configuration/boards/btt-octopus-pro-h723-11/config.cfg
@@ -42,7 +42,7 @@ aliases:
   filament_sensor_motion_pin=PG14,
   # RatRig VAOC
   ratrig_vaoc_probe_pin=PG10,
-  ratrig_vaoc_led_pin=PB0,
+  ratrig_vaoc_led_pin=PB10,
   ratrig_vaoc_fan_pin=PD13,
   # chamber lighting
   chamber_lighting_pin=PB11,


### PR DESCRIPTION
Pin corrections on Octopus Pro H723 V1.1 (VAOC led) and EBB42 Gen 2 (filament sensor)

This is a potentially **breaking change** for machines using the EBB42 Gen 2 toolboard:
* `filament_sensor_runout_pin` has been changed from `PA3` to `PA10`

This is a potentially **breaking change** for machines using the Octopus Pro H723 V1.1 control board:
* `ratrig_vaoc_led_pin` has been changed from `PB0` to `PB10`
