### PR TITLE
fix(macros): minor rework of PAUSE/RESUME, notably to fix an issue with IDEX spool join

### DIFF
--- a/configuration/macros.cfg
+++ b/configuration/macros.cfg
@@ -18,41 +18,45 @@ variable_retract: 1.5           # retraction in mm when print is paused
 variable_fan_speed: 0           # internal use only. Do not touch!
 variable_idex_mode: ""          # internal use only. Do not touch!
 variable_idex_toolhead: 0       # internal use only. Do not touch!
-variable_idex_toolhead_x: 0.0   # internal use only. Do not touch!
-variable_idex_toolhead_y: 0.0   # internal use only. Do not touch!
-variable_idex_toolhead_z: 0.0   # internal use only. Do not touch!
 gcode:
 	RATOS_ECHO MSG="Pausing print..."
-
-	# parameter
-	{% set runout_detected = true if params.RUNOUT|default(false)|lower == 'true' else false %}
 
 	# visual feedback
 	_LED_PAUSE
 
+	# Call internal PAUSE command. At the time of writing, Klipper's internal PAUSE implementation includes:
+	# - pause virtual SD printing
+	# - SAVE_GCODE_STATE NAME=PAUSE_STATE
+	PAUSE_BASE
+	
+	# Wait for pending moves
+	M400
+
+	# the at-rest-after-pause printer.toolhead.position can safely be inspected
+	# in _PAUSE_AFTER_QUISECE
+	_PAUSE_AFTER_QUISECE {rawparams}
+
+[gcode_macro _PAUSE_AFTER_QUISECE]
+description: Implementation of PAUSE macro after SD card printing has been suspended and any pending toolhead moves have been completed.
+gcode:
+	# parameter
+	{% set runout_detected = true if params.RUNOUT|default(false)|lower == 'true' else false %}
+
 	# IDEX mode
+	{% set is_idex = printer["dual_carriage"] is defined %}
 	{% set idex_mode = '' %}
-	{% if printer["dual_carriage"] is defined %}
+	{% if is_idex %}
 		{% set idex_mode = printer["dual_carriage"].carriage_1|lower %}
 		{% set idex_toolhead = 1 if idex_mode == 'primary' else 0 %}
-	{% endif %}
-
-	# Save gcode state
-	{% if printer["dual_carriage"] is not defined %}
-		SAVE_GCODE_STATE NAME=PAUSE_state
-	{% else %}
 		SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=idex_mode VALUE='"{idex_mode}"'
 		SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=idex_toolhead VALUE={idex_toolhead}
-		SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=idex_toolhead_x VALUE={printer.gcode_move.gcode_position.x|float}
-		SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=idex_toolhead_y VALUE={printer.gcode_move.gcode_position.y|float}
-		SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=idex_toolhead_z VALUE={printer.gcode_move.gcode_position.z|float}
-		DEBUG_ECHO PREFIX="PAUSE" MSG="idex_mode: {idex_mode}, idex_toolhead: {idex_toolhead}, idex_toolhead_x: {idex_toolhead_x}, idex_toolhead_y: {idex_toolhead_y}, idex_toolhead_z: {idex_toolhead_z}"
+		DEBUG_ECHO PREFIX="PAUSE" MSG="idex_mode: {idex_mode}, idex_toolhead: {idex_toolhead}"
 	{% endif %}
 
 	# set is_printing_gcode state
 	SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=is_printing_gcode VALUE=False
 
-	# Handle toolhead settings
+	# Handle toolhead settings (these are the settings controlled by SET_VELOCITY_LIMIT)
 	CACHE_TOOLHEAD_SETTINGS KEY="pause"
 	SET_MACRO_TRAVEL_SETTINGS
 
@@ -65,11 +69,8 @@ gcode:
 		{% set z_safe = max_z - current_z %}
 	{% endif %}
 
-	# Call internal PAUSE command
-	PAUSE_BASE
-
 	# Cache part cooling fan speed 
-	{% if printer["dual_carriage"] is not defined %}
+	{% if not is_idex %}
 		SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=fan_speed VALUE={printer["fan"].speed|float}
 	{% else %}
 		{% if idex_mode == 'copy' or idex_mode == 'mirror' %}
@@ -88,7 +89,7 @@ gcode:
 
 	# Can extruder extrude
 	{% set can_extrude = true if printer['extruder'].can_extrude|lower == 'true' else false %}
-	{% if idex_mode != '' %}
+	{% if is_idex %}
 		{% if idex_mode == 'copy' or idex_mode == 'mirror' %}
 			{% set can_extrude = true if printer['extruder'].can_extrude|lower == 'true' and printer['extruder1'].can_extrude|lower == 'true' else false %}
 		{% else %}
@@ -124,7 +125,7 @@ gcode:
 		G91                        # Relative positioning
 		G1 Z{z_safe} F{z_speed}
 		G90                        # Absolute positioning
-		{% if printer["dual_carriage"] is not defined %}
+		{% if not is_idex %}
 			# DEFAULT
 			_PARK LOCATION={pause_print_park_in} X={pause_print_park_x}
 		{% else %}
@@ -159,14 +160,15 @@ gcode:
 	{% set speed = printer["gcode_macro RatOS"].macro_travel_speed|float * 60 %}
 
 	# Target IDEX mode
+	{% set is_idex = printer["dual_carriage"] is defined %}
 	{% set target_idex_mode = '' %}
-	{% if printer["dual_carriage"] is defined %}
+	{% if is_idex %}
 		{% set target_idex_mode = printer["gcode_macro PAUSE"].idex_mode|lower %}
 	{% endif %}
 
 	# Can extruder extrude
 	{% set can_extrude = true if printer['extruder'].can_extrude|lower == 'true' else false %}
-	{% if target_idex_mode != '' %}
+	{% if is_idex %}
 		{% if target_idex_mode == 'copy' or target_idex_mode == 'mirror' %}
 			{% set can_extrude = true if printer['extruder'].can_extrude|lower == 'true' and printer['extruder1'].can_extrude|lower == 'true' else false %}
 		{% else %}
@@ -178,7 +180,7 @@ gcode:
 
 	# Turn part cooling back fan on 
 	{% set fan_speed = printer["gcode_macro PAUSE"].fan_speed|float %}
-	{% if printer["dual_carriage"] is not defined %}
+	{% if not is_idex %}
 		M106 S{(fan_speed * 255)}
 	{% else %}
 		{% if idex_mode == 'copy' or idex_mode == 'mirror' %}
@@ -206,7 +208,7 @@ gcode:
 	{% endif %}
 
 	# Restore IDEX state
-	{% if printer["dual_carriage"] is defined %}
+	{% if is_idex %}
 		{% if target_idex_mode == "copy" %}
 			_IDEX_COPY DANCE=0
 		{% elif target_idex_mode == "mirror" %}
@@ -218,16 +220,10 @@ gcode:
 				_SELECT_TOOL T={printer["gcode_macro PAUSE"].idex_toolhead} X=-1 Y=-1 TOOLSHIFT=false
 			{% endif %}
 		{% endif %}
-		# restore IDEX toolhead position
-		{% set x = printer["gcode_macro PAUSE"].idex_toolhead_x|float %}
-		{% set y = printer["gcode_macro PAUSE"].idex_toolhead_y|float %}
-		{% set z = printer["gcode_macro PAUSE"].idex_toolhead_z|float %}
-		G1 X{x} Y{y} Z{z} F{speed}
-		{% if params.TOOLHEAD is defined %}
-			# overwrite internal gcode state to make sure new toolheads offsets are getting applied 
-			SAVE_GCODE_STATE NAME=PAUSE_STATE
-		{% endif %}
 	{% endif %}
+
+	# Move to resume position before priming
+	RESTORE_GCODE_STATE NAME=PAUSE_STATE MOVE=1 MOVE_SPEED={speed}
 
 	# Prime
 	{% if params.TOOLHEAD is not defined %}
@@ -241,15 +237,12 @@ gcode:
 		{% endif %}
 	{% endif %}
 
-	# Restore gcode state
-	{% if printer["dual_carriage"] is not defined %}
-		RESTORE_GCODE_STATE NAME=PAUSE_state MOVE=1 MOVE_SPEED={speed}
-	{% endif %}
-
 	# set is_printing_gcode state
 	SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=is_printing_gcode VALUE=True
 
-	# Call internal RESUME command
+	# Call internal RESUME command. At the time of writing, Klipper's internal RESUME implementation includes:
+	# - RESTORE_GCODE_STATE NAME=PAUSE_STATE MOVE=1 MOVE_SPEED={VELOCITY|default(recover_velocity)}
+	# - resume virtual SD printing
 	RESUME_BASE
 
 	# visual feedback


### PR DESCRIPTION
- Fixes an issue where the printing speed after resume from spool join would be the RatOS macro travel speed, not the correct speed for the print.
- Remove IDEX position handling complexity that's no longer required since the move to `[named_offsets]`.
- Remove redundant use of second gcode state key.
- Normalize resume move/unretract ordering so it's the same for IDEX and non-IDEX.
- Delegate most of the `PAUSE` implementation to a secondary macro after performing the underlying pause and waiting for moves to complete to ensure that `printer.toolhead.position` is in a stable state.
- Some minor code cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pause and resume reliability, especially for printers with IDEX setups.
  * Resume now restores print state more consistently, including fan speed and motion behavior.
  * Reduced the chance of incorrect toolhead positioning or state mismatches after pausing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->