### PR TITLE
feat(macros): add user hooks to _PURGE_FILAMENT

### DIFF
--- a/configuration/macros/load_filament.cfg
+++ b/configuration/macros/load_filament.cfg
@@ -325,10 +325,9 @@ gcode:
 gcode:
 	# parameter
 	{% set toolhead = params.TOOLHEAD|int %}
-	{% set e = params.E|int %}
-	{% set r = params.R|default(0)|int %}
+	{% set e = params.E|float %}
+	{% set r = params.R|default(0)|float %}
 
-	DEBUG_ECHO PREFIX="_PURGE_FILAMENT" MSG="TOOLHEAD: {toolhead}, E: {e}"
 	DEBUG_ECHO PREFIX="_PURGE_FILAMENT" MSG="TOOLHEAD: {toolhead}, E: {e}, R: {r}"
 
 	# purge filament

--- a/configuration/macros/load_filament.cfg
+++ b/configuration/macros/load_filament.cfg
@@ -329,6 +329,7 @@ gcode:
 	{% set r = params.R|default(0)|int %}
 
 	DEBUG_ECHO PREFIX="_PURGE_FILAMENT" MSG="TOOLHEAD: {toolhead}, E: {e}"
+	DEBUG_ECHO PREFIX="_PURGE_FILAMENT" MSG="TOOLHEAD: {toolhead}, E: {e}, R: {r}"
 
 	# purge filament
 	{% if e > 0 %}

--- a/configuration/macros/load_filament.cfg
+++ b/configuration/macros/load_filament.cfg
@@ -332,6 +332,7 @@ gcode:
 
 	# purge filament
 	{% if e > 0 %}
+		_USER_BEFORE_PURGE_FILAMENT TOOLHEAD={toolhead}
 
 		# purge
 		G92 E0                                 # Reset extrusion distance
@@ -370,6 +371,7 @@ gcode:
 			{% endif %}
 		{% endif %}
 
+		_USER_AFTER_PURGE_FILAMENT TOOLHEAD={toolhead}
 	{% endif %}
 
 

--- a/configuration/macros/user-hooks.cfg
+++ b/configuration/macros/user-hooks.cfg
@@ -66,3 +66,11 @@ gcode:
 
 [gcode_macro _USER_AFTER_IDLE_TIMEOUT]
 gcode:
+
+# Filament operations hooks
+
+[gcode_macro _USER_BEFORE_PURGE_FILAMENT]
+gcode:
+
+[gcode_macro _USER_AFTER_PURGE_FILAMENT]
+gcode:


### PR DESCRIPTION
- Added stub _USER_BEFORE_PURGE_FILAMENT TOOLHEAD=0|1 and _USER_AFTER_PURGE_FILAMENT TOOLHEAD=0|1 which are called around the main block in _PURGE_FILAMENT, but only if purging will actually take place.
- parse the E and R parameters in _PURGE_FILAMENT as floats not ints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new customization points around filament purge, allowing advanced users to run their own actions before and after the purge routine.
* **Bug Fixes**
  * Improved purge parameter handling so values are read more accurately, including support for decimal inputs.
  * Expanded debug output to show additional purge details for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->