### PR TITLE
fix(idex): refine parking space sanity check to detect and allow configurations where T1 homes against T0

### DIFF
--- a/configuration/macros.cfg
+++ b/configuration/macros.cfg
@@ -328,6 +328,7 @@ gcode:
 		{% set toolchange_standby_temp = printer["gcode_macro RatOS"].toolchange_standby_temp|default(-1)|float %}
 	{% endif %}
 	{% set z_speed = printer["gcode_macro RatOS"].macro_z_speed|float * 60 %}
+	{% set printable_x_max = printer["gcode_macro RatOS"].printable_x_max|float %}
 
 	# beacon contact config
 	{% set beacon_contact_start_print_true_zero = true if printer["gcode_macro RatOS"].beacon_contact_start_print_true_zero|default(false)|lower == 'true' else false %}
@@ -456,7 +457,12 @@ gcode:
 		{% set dual_carriage_position_max = printer.fastconfig.settings.dual_carriage.position_max|float %}
 		{% set dual_carriage_position_endstop = printer.fastconfig.settings.dual_carriage.position_endstop|float %}
 		{% set x_parking_space = parking_position_t0 - (stepper_x_position_endstop , stepper_x_position_min)|max %}
-		{% set dc_parking_space = (dual_carriage_position_endstop , dual_carriage_position_max)|min - parking_position_t1 %}
+		{% if dual_carriage_position_endstop < printable_x_max / 2.0 %}
+			# Assume that T1 homes against T0, DC endstop position is not relevant for parking space calculation
+			{% set dc_parking_space = dual_carriage_position_max - parking_position_t1 %}
+		{% else %}
+			{% set dc_parking_space = (dual_carriage_position_endstop , dual_carriage_position_max)|min - parking_position_t1 %}
+		{% endif %}
 		{% if svv.idex_xoffset|abs >= (x_parking_space - 0.5) or svv.idex_xoffset|abs >= (dc_parking_space - 0.5) %}
 			_LED_START_PRINTING_ERROR
 			{ action_raise_error("Toolhead x-offset is too high for the available parking space. Calibrate your X and DC endstop positions and make sure you stay below 1mm." % (copy_mode_max_width)) }
@@ -473,8 +479,6 @@ gcode:
 
 		# reset object xoffset
 		SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=object_xoffset VALUE=0
-
-		{% set printable_x_max = printer["gcode_macro RatOS"].printable_x_max|float %}
 
 		# ToDo!
 		# get boundary box from slicer if already available on PS and SS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dual-extruder start-up checks so the printer uses the correct parking-space boundary more consistently.
  * Made print setup values available earlier in the start sequence, reducing the chance of incorrect toolhead positioning checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->