### PR TITLE
Update gear ratio in clockwork-2 configuration

### DIFF
--- a/configuration/extruders/clockwork-2.cfg
+++ b/configuration/extruders/clockwork-2.cfg
@@ -10,7 +10,7 @@
 
 [extruder]
 rotation_distance: 22.6789511
-gear_ratio: 50:17
+gear_ratio: 50:10
 full_steps_per_rotation: 200
 filament_diameter: 1.750
 max_extrude_only_velocity: 60


### PR DESCRIPTION
Clockwork is using a gear_ratio of 50:17, but Clockwork 2 is 50:10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Clockwork-2 extruder gear ratio for improved extrusion accuracy and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->